### PR TITLE
Fixes for Windows

### DIFF
--- a/src/GenerateProgrammaticPipelineFromConfig/Help.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Help.php
@@ -64,10 +64,11 @@ EOT;
      */
     public function __invoke($resource = STDOUT)
     {
-        // Use basename of command if it is a realpath
-        $command = (file_exists($this->command) && realpath($this->command) === $this->command)
-            ? basename($this->command)
-            : $this->command;
+        // Find relative command path
+        $command = strtr(realpath($this->command) ?: $this->command, [
+            getcwd() . DIRECTORY_SEPARATOR => '',
+            'zendframework' . DIRECTORY_SEPARATOR . 'zend-expressive-tooling' . DIRECTORY_SEPARATOR => '',
+        ]);
 
         $this->helper->writeLine(sprintf(
             self::TEMPLATE,

--- a/src/MigrateOriginalMessageCalls/Help.php
+++ b/src/MigrateOriginalMessageCalls/Help.php
@@ -75,10 +75,11 @@ EOT;
      */
     public function __invoke($resource = STDOUT)
     {
-        // Use basename of command if it is a realpath
-        $command = (file_exists($this->command) && realpath($this->command) === $this->command)
-            ? basename($this->command)
-            : $this->command;
+        // Find relative command path
+        $command = strtr(realpath($this->command) ?: $this->command, [
+            getcwd() . DIRECTORY_SEPARATOR => '',
+            'zendframework' . DIRECTORY_SEPARATOR . 'zend-expressive-tooling' . DIRECTORY_SEPARATOR => '',
+        ]);
 
         $this->helper->writeLine(sprintf(
             self::TEMPLATE,

--- a/src/ScanForErrorMiddleware/Help.php
+++ b/src/ScanForErrorMiddleware/Help.php
@@ -61,10 +61,11 @@ EOT;
      */
     public function __invoke($resource = STDOUT)
     {
-        // Use basename of command if it is a realpath
-        $command = (file_exists($this->command) && realpath($this->command) === $this->command)
-            ? basename($this->command)
-            : $this->command;
+        // Find relative command path
+        $command = strtr(realpath($this->command) ?: $this->command, [
+            getcwd() . DIRECTORY_SEPARATOR => '',
+            'zendframework' . DIRECTORY_SEPARATOR . 'zend-expressive-tooling' . DIRECTORY_SEPARATOR => '',
+        ]);
 
         $this->helper->writeLine(sprintf(
             self::TEMPLATE,

--- a/test/GenerateProgrammaticPipelineFromConfig/HelpTest.php
+++ b/test/GenerateProgrammaticPipelineFromConfig/HelpTest.php
@@ -22,7 +22,7 @@ class HelpTest extends TestCase
         $console
             ->writeLine(
                 Argument::that(function ($message) {
-                    return false !== strstr($message, 'generate-programmatic-pipeline-from-config');
+                    return false !== strpos($message, 'generate-programmatic-pipeline-from-config');
                 }),
                 true,
                 $resource
@@ -45,7 +45,7 @@ class HelpTest extends TestCase
         $console
             ->writeLine(
                 Argument::that(function ($message) {
-                    return false !== strstr($message, basename(__FILE__));
+                    return false !== strpos($message, basename(__FILE__));
                 }),
                 true,
                 $resource

--- a/test/GenerateProgrammaticPipelineFromConfig/HelpTest.php
+++ b/test/GenerateProgrammaticPipelineFromConfig/HelpTest.php
@@ -16,7 +16,7 @@ class HelpTest extends TestCase
 {
     public function testWritesHelpMessageToConsoleUsingCommandProvidedAtInstantiationAndResourceAtInvocation()
     {
-        $resource = fopen('php://temp', 'w+');
+        $resource = fopen('php://temp', 'wb+');
 
         $console = $this->prophesize(ConsoleHelper::class);
         $console
@@ -39,7 +39,7 @@ class HelpTest extends TestCase
 
     public function testTruncatesCommandToBasenameIfItIsARealpath()
     {
-        $resource = fopen('php://temp', 'w+');
+        $resource = fopen('php://temp', 'wb+');
 
         $console = $this->prophesize(ConsoleHelper::class);
         $console

--- a/test/MigrateOriginalMessageCalls/HelpTest.php
+++ b/test/MigrateOriginalMessageCalls/HelpTest.php
@@ -22,7 +22,7 @@ class HelpTest extends TestCase
         $console
             ->writeLine(
                 Argument::that(function ($message) {
-                    return false !== strstr($message, 'migrate-original-message-calls');
+                    return false !== strpos($message, 'migrate-original-message-calls');
                 }),
                 true,
                 $resource
@@ -45,7 +45,7 @@ class HelpTest extends TestCase
         $console
             ->writeLine(
                 Argument::that(function ($message) {
-                    return false !== strstr($message, basename(__FILE__));
+                    return false !== strpos($message, basename(__FILE__));
                 }),
                 true,
                 $resource

--- a/test/MigrateOriginalMessageCalls/HelpTest.php
+++ b/test/MigrateOriginalMessageCalls/HelpTest.php
@@ -16,7 +16,7 @@ class HelpTest extends TestCase
 {
     public function testWritesHelpMessageToConsoleUsingCommandProvidedAtInstantiationAndResourceAtInvocation()
     {
-        $resource = fopen('php://temp', 'w+');
+        $resource = fopen('php://temp', 'wb+');
 
         $console = $this->prophesize(ConsoleHelper::class);
         $console
@@ -39,7 +39,7 @@ class HelpTest extends TestCase
 
     public function testTruncatesCommandToBasenameIfItIsARealpath()
     {
-        $resource = fopen('php://temp', 'w+');
+        $resource = fopen('php://temp', 'wb+');
 
         $console = $this->prophesize(ConsoleHelper::class);
         $console

--- a/test/MigrateOriginalMessageCalls/ProjectSetupTrait.php
+++ b/test/MigrateOriginalMessageCalls/ProjectSetupTrait.php
@@ -18,7 +18,7 @@ trait ProjectSetupTrait
 {
     public function setupSrcDir($dir)
     {
-        $base = realpath(__DIR__ . '/TestAsset') . '/';
+        $base = realpath(__DIR__ . '/TestAsset') . DIRECTORY_SEPARATOR;
         $rdi = new RecursiveDirectoryIterator($base . 'src');
         $rii = new RecursiveIteratorIterator($rdi);
 
@@ -29,7 +29,7 @@ trait ProjectSetupTrait
 
             $filename = $file->getRealPath();
             $contents = file_get_contents($filename);
-            $name = str_replace($base, '', $filename);
+            $name = strtr($filename, [$base => '', DIRECTORY_SEPARATOR => '/']);
             vfsStream::newFile($name)
                 ->at($dir)
                 ->setContent($contents);

--- a/test/ScanForErrorMiddleware/HelpTest.php
+++ b/test/ScanForErrorMiddleware/HelpTest.php
@@ -16,7 +16,7 @@ class HelpTest extends TestCase
 {
     public function testWritesHelpMessageToConsoleUsingCommandProvidedAtInstantiationAndResourceAtInvocation()
     {
-        $resource = fopen('php://temp', 'w+');
+        $resource = fopen('php://temp', 'wb+');
 
         $console = $this->prophesize(ConsoleHelper::class);
         $console
@@ -39,7 +39,7 @@ class HelpTest extends TestCase
 
     public function testTruncatesCommandToBasenameIfItIsARealpath()
     {
-        $resource = fopen('php://temp', 'w+');
+        $resource = fopen('php://temp', 'wb+');
 
         $console = $this->prophesize(ConsoleHelper::class);
         $console

--- a/test/ScanForErrorMiddleware/HelpTest.php
+++ b/test/ScanForErrorMiddleware/HelpTest.php
@@ -22,7 +22,7 @@ class HelpTest extends TestCase
         $console
             ->writeLine(
                 Argument::that(function ($message) {
-                    return false !== strstr($message, 'scan-for-error-middleware');
+                    return false !== strpos($message, 'scan-for-error-middleware');
                 }),
                 true,
                 $resource
@@ -45,7 +45,7 @@ class HelpTest extends TestCase
         $console
             ->writeLine(
                 Argument::that(function ($message) {
-                    return false !== strstr($message, basename(__FILE__));
+                    return false !== strpos($message, basename(__FILE__));
                 }),
                 true,
                 $resource


### PR DESCRIPTION
- fix relative paths to scripts in help message
- use binary safe mode - `wb+`
- use `strpos` instead of `strstr` (save memory)
- `DIRECTORY_SEPARATOR` instead of `/`

In that occasion I think there is a bug or we are just using it wrong, so adding new file:
`vfsStream::newFile($name)` doesn't change windows directory separator `\` to `/` but then `vfsStream::path($name)` returns path always with `/`, and it cause issues on windows.
In this PR it is fixed, because in filename we replace `DIRECTORY_SEPARATOR` to `/`. I'll investigate it a bit more and create proper issue to `vfsStream` if needed.