### PR TITLE
Inject implicit HEAD, OPTIONS middleware into generated pipeline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,14 +47,15 @@
     ],
     "scripts": {
         "check": [
+            "@license-check",
             "@cs-check",
             "@test"
         ],
-        "upload-coverage": "coveralls -v",
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
+        "license-check": "vendor/bin/docheader check src/",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --coverage-clover clover.xml",
-        "license-check": "vendor/bin/docheader check src/"
+        "upload-coverage": "coveralls -v"
     }
 }

--- a/src/GenerateProgrammaticPipelineFromConfig/Generator.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Generator.php
@@ -10,6 +10,8 @@ namespace Zend\Expressive\Tooling\GenerateProgrammaticPipelineFromConfig;
 use ArrayObject;
 use Traversable;
 use Zend\Expressive\Application;
+use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
+use Zend\Expressive\Middleware\ImplicitOptionsMiddleware;
 use Zend\Expressive\Router\Route;
 use Zend\Stdlib\SplPriorityQueue;
 
@@ -30,6 +32,8 @@ use Zend\Expressive\Container\ErrorHandlerFactory;
 use Zend\Expressive\Container\ErrorResponseGeneratorFactory;
 use Zend\Expressive\Container\NotFoundHandlerFactory;
 use Zend\Expressive\Middleware\ErrorResponseGenerator;
+use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
+use Zend\Expressive\Middleware\ImplicitOptionsMiddleware;
 use Zend\Expressive\Middleware\NotFoundHandler;
 use Zend\Stratigility\Middleware\ErrorHandler;
 use Zend\Stratigility\Middleware\OriginalMessages;
@@ -37,6 +41,8 @@ use Zend\Stratigility\Middleware\OriginalMessages;
 return [
     'dependencies' => [
         'invokables' => [
+            ImplicitHeadMiddleware::class => ImplicitHeadMiddleware::class,
+            ImplicitOptionsMiddleware::class => ImplicitOptionsMiddleware::class,
             OriginalMessages::class => OriginalMessages::class,
         ],
         'factories' => [
@@ -194,6 +200,16 @@ EOT;
                 && $spec['middleware'] === Application::ROUTING_MIDDLEWARE
             ) {
                 $pipeline[] = '$app->pipeRoutingMiddleware();';
+                $pipeline[] = sprintf(
+                    self::TEMPLATE_PIPELINE_NO_PATH,
+                    'pipe',
+                    $this->formatMiddleware(ImplicitHeadMiddleware::class)
+                );
+                $pipeline[] = sprintf(
+                    self::TEMPLATE_PIPELINE_NO_PATH,
+                    'pipe',
+                    $this->formatMiddleware(ImplicitOptionsMiddleware::class)
+                );
                 continue;
             }
 

--- a/test/GenerateProgrammaticPipelineFromConfig/TestAsset/expected/config/autoload/programmatic-pipeline.global.php
+++ b/test/GenerateProgrammaticPipelineFromConfig/TestAsset/expected/config/autoload/programmatic-pipeline.global.php
@@ -7,6 +7,8 @@ use Zend\Expressive\Container\ErrorHandlerFactory;
 use Zend\Expressive\Container\ErrorResponseGeneratorFactory;
 use Zend\Expressive\Container\NotFoundHandlerFactory;
 use Zend\Expressive\Middleware\ErrorResponseGenerator;
+use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
+use Zend\Expressive\Middleware\ImplicitOptionsMiddleware;
 use Zend\Expressive\Middleware\NotFoundHandler;
 use Zend\Stratigility\Middleware\ErrorHandler;
 use Zend\Stratigility\Middleware\OriginalMessages;
@@ -14,6 +16,8 @@ use Zend\Stratigility\Middleware\OriginalMessages;
 return [
     'dependencies' => [
         'invokables' => [
+            ImplicitHeadMiddleware::class => ImplicitHeadMiddleware::class,
+            ImplicitOptionsMiddleware::class => ImplicitOptionsMiddleware::class,
             OriginalMessages::class => OriginalMessages::class,
         ],
         'factories' => [

--- a/test/GenerateProgrammaticPipelineFromConfig/TestAsset/expected/config/pipeline.php
+++ b/test/GenerateProgrammaticPipelineFromConfig/TestAsset/expected/config/pipeline.php
@@ -15,6 +15,8 @@ $app->pipe('/api', [
     'Api\\Middleware\\Validation',
 ]);
 $app->pipeRoutingMiddleware();
+$app->pipe('Zend\\Expressive\\Middleware\\ImplicitHeadMiddleware');
+$app->pipe('Zend\\Expressive\\Middleware\\ImplicitOptionsMiddleware');
 $app->pipe('Zend\\Expressive\\Helper\\UrlHelperMiddleware');
 $app->pipeDispatchMiddleware();
 $app->pipe('App\\Middleware\\NotFoundHandler');


### PR DESCRIPTION
`Generator` now does the following:

- Adds dependency configuration for the implicit HEAD and OPTIONS middleware to `config/autoload/programmatic-pipeline.global.php`.
- Adds entries for the implicit HEAD and OPTIONS middleware to the pipeline immediately following the routing middleware.

This is to support the changes in zendframework/zend-expressive#413, and should not be merged or tagged before that functionality has been released in Expressive 1.1.