### PR TITLE
Update to expected Expressive 2.0 pipelines

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,5 +1,5 @@
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) %regexp:(20\d{2}-)?%%year% Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */

--- a/composer.lock
+++ b/composer.lock
@@ -4,6 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
+    "hash": "38ef8f5d3a6f14ecc6b29fd870761df0",
     "content-hash": "5136c7a728fa809a3b3aeea73cd69664",
     "packages": [
         {
@@ -54,7 +55,7 @@
                 "request",
                 "response"
             ],
-            "time": "2017-02-09T16:10:21+00:00"
+            "time": "2017-02-09 16:10:21"
         },
         {
             "name": "http-interop/http-middleware",
@@ -106,7 +107,7 @@
                 "request",
                 "response"
             ],
-            "time": "2017-01-14T15:23:42+00:00"
+            "time": "2017-01-14 15:23:42"
         },
         {
             "name": "psr/container",
@@ -155,7 +156,7 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-02-14T16:28:37+00:00"
+            "time": "2017-02-14 16:28:37"
         },
         {
             "name": "psr/http-message",
@@ -205,7 +206,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2016-08-06 14:39:51"
         },
         {
             "name": "zendframework/zend-code",
@@ -258,7 +259,7 @@
                 "code",
                 "zf2"
             ],
-            "time": "2016-10-24T13:23:32+00:00"
+            "time": "2016-10-24 13:23:32"
         },
         {
             "name": "zendframework/zend-diactoros",
@@ -308,7 +309,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-01-23T04:53:24+00:00"
+            "time": "2017-01-23 04:53:24"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -352,7 +353,7 @@
                 "escaper",
                 "zf2"
             ],
-            "time": "2016-06-30T19:48:38+00:00"
+            "time": "2016-06-30 19:48:38"
         },
         {
             "name": "zendframework/zend-eventmanager",
@@ -406,7 +407,7 @@
                 "events",
                 "zf2"
             ],
-            "time": "2016-12-19T21:47:12+00:00"
+            "time": "2016-12-19 21:47:12"
         },
         {
             "name": "zendframework/zend-expressive",
@@ -414,12 +415,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive.git",
-                "reference": "2534c1ae5ed6b5c6c34d4dd63282a2d0561d7df9"
+                "reference": "697bb1cc501357a37a961f2252eee72a43f20341"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive/zipball/2534c1ae5ed6b5c6c34d4dd63282a2d0561d7df9",
-                "reference": "2534c1ae5ed6b5c6c34d4dd63282a2d0561d7df9",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive/zipball/697bb1cc501357a37a961f2252eee72a43f20341",
+                "reference": "697bb1cc501357a37a961f2252eee72a43f20341",
                 "shasum": ""
             },
             "require": {
@@ -480,7 +481,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-02-15 19:44:36"
+            "time": "2017-02-15 22:33:22"
         },
         {
             "name": "zendframework/zend-expressive-router",
@@ -536,7 +537,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-01-24T22:28:12+00:00"
+            "time": "2017-01-24 22:28:12"
         },
         {
             "name": "zendframework/zend-expressive-template",
@@ -585,7 +586,7 @@
                 "expressive",
                 "template"
             ],
-            "time": "2017-01-11T18:42:34+00:00"
+            "time": "2017-01-11 18:42:34"
         },
         {
             "name": "zendframework/zend-stdlib",
@@ -630,7 +631,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2016-09-13T14:38:50+00:00"
+            "time": "2016-09-13 14:38:50"
         },
         {
             "name": "zendframework/zend-stratigility",
@@ -684,7 +685,7 @@
                 "middleware",
                 "psr-7"
             ],
-            "time": "2017-01-25T19:16:16+00:00"
+            "time": "2017-01-25 19:16:16"
         }
     ],
     "packages-dev": [
@@ -740,7 +741,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2015-06-14 21:17:01"
         },
         {
             "name": "malukenho/docheader",
@@ -790,7 +791,7 @@
                 "code standard",
                 "license"
             ],
-            "time": "2016-11-17T16:46:05+00:00"
+            "time": "2016-11-17 16:46:05"
         },
         {
             "name": "mikey179/vfsStream",
@@ -836,7 +837,7 @@
             ],
             "description": "Virtual file system to mock the real file system in unit tests.",
             "homepage": "http://vfs.bovigo.org/",
-            "time": "2016-07-18T14:02:57+00:00"
+            "time": "2016-07-18 14:02:57"
         },
         {
             "name": "myclabs/deep-copy",
@@ -878,7 +879,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-01-26T22:05:40+00:00"
+            "time": "2017-01-26 22:05:40"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -932,7 +933,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2015-12-27 11:43:31"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -977,7 +978,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30T07:12:33+00:00"
+            "time": "2016-09-30 07:12:33"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -1024,7 +1025,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25T06:54:22+00:00"
+            "time": "2016-11-25 06:54:22"
         },
         {
             "name": "phpspec/prophecy",
@@ -1087,44 +1088,43 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21T14:58:47+00:00"
+            "time": "2016-11-21 14:58:47"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c19cfc7cbb0e9338d8c469c7eedecc2a428b0971"
+                "reference": "e7d7a4acca58e45bdfd00221563d131cfb04ba96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c19cfc7cbb0e9338d8c469c7eedecc2a428b0971",
-                "reference": "c19cfc7cbb0e9338d8c469c7eedecc2a428b0971",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/e7d7a4acca58e45bdfd00221563d131cfb04ba96",
+                "reference": "e7d7a4acca58e45bdfd00221563d131cfb04ba96",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
+                "php": "^7.0",
+                "phpunit/php-file-iterator": "^1.3",
+                "phpunit/php-text-template": "^1.2",
                 "phpunit/php-token-stream": "^1.4.2",
-                "sebastian/code-unit-reverse-lookup": "~1.0",
-                "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "~1.0|~2.0"
+                "sebastian/code-unit-reverse-lookup": "^1.0",
+                "sebastian/environment": "^2.0",
+                "sebastian/version": "^2.0"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "^5.4"
+                "ext-xdebug": "^2.5",
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-dom": "*",
-                "ext-xdebug": ">=2.4.0",
                 "ext-xmlwriter": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -1150,7 +1150,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-01-20T15:06:43+00:00"
+            "time": "2017-02-02 10:35:41"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1197,7 +1197,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1238,7 +1238,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "time": "2015-06-21 13:50:34"
         },
         {
             "name": "phpunit/php-timer",
@@ -1282,7 +1282,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12T18:03:57+00:00"
+            "time": "2016-05-12 18:03:57"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -1331,20 +1331,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15T14:06:22+00:00"
+            "time": "2016-11-15 14:06:22"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.13",
+            "version": "6.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "60ebeed87a35ea46fd7f7d8029df2d6f013ebb34"
+                "reference": "e702506af102d0dc5312dd24b8e97fd6e58ce3ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/60ebeed87a35ea46fd7f7d8029df2d6f013ebb34",
-                "reference": "60ebeed87a35ea46fd7f7d8029df2d6f013ebb34",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e702506af102d0dc5312dd24b8e97fd6e58ce3ba",
+                "reference": "e702506af102d0dc5312dd24b8e97fd6e58ce3ba",
                 "shasum": ""
             },
             "require": {
@@ -1353,33 +1353,33 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
+                "myclabs/deep-copy": "^1.3",
+                "php": "^7.0",
                 "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^4.0.4",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-code-coverage": "^5.0",
+                "phpunit/php-file-iterator": "^1.4",
+                "phpunit/php-text-template": "^1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
+                "phpunit/phpunit-mock-objects": "^4.0",
                 "sebastian/comparator": "^1.2.4",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "^1.3.4 || ^2.0",
-                "sebastian/exporter": "~2.0",
+                "sebastian/diff": "^1.2",
+                "sebastian/environment": "^2.0",
+                "sebastian/exporter": "^2.0",
                 "sebastian/global-state": "^1.1",
-                "sebastian/object-enumerator": "~2.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "~1.0|~2.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "sebastian/object-enumerator": "^2.0",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2"
+                "phpdocumentor/reflection-docblock": "3.0.2",
+                "phpunit/dbunit": "<3.0"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "~1.1"
+                "phpunit/php-invoker": "^1.1"
             },
             "bin": [
                 "phpunit"
@@ -1387,7 +1387,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.7.x-dev"
+                    "dev-master": "6.0.x-dev"
                 }
             },
             "autoload": {
@@ -1413,33 +1413,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-10T09:05:10+00:00"
+            "time": "2017-02-08 05:57:26"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.3",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24"
+                "reference": "3819745c44f3aff9518fd655f320c4535d541af7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
-                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3819745c44f3aff9518fd655f320c4535d541af7",
+                "reference": "3819745c44f3aff9518fd655f320c4535d541af7",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
+                "php": "^7.0",
                 "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2 || ^2.0"
+                "sebastian/exporter": "^2.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<5.4.0"
+                "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.4"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1447,7 +1447,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -1472,7 +1472,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-12-08T20:27:08+00:00"
+            "time": "2017-02-02 10:36:38"
         },
         {
             "name": "psr/log",
@@ -1519,7 +1519,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2016-10-10 12:19:37"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1564,7 +1564,7 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2016-02-13T06:45:14+00:00"
+            "time": "2016-02-13 06:45:14"
         },
         {
             "name": "sebastian/comparator",
@@ -1628,7 +1628,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2017-01-29 09:50:25"
         },
         {
             "name": "sebastian/diff",
@@ -1680,7 +1680,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08T07:14:41+00:00"
+            "time": "2015-12-08 07:14:41"
         },
         {
             "name": "sebastian/environment",
@@ -1730,7 +1730,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "time": "2016-11-26 07:53:53"
         },
         {
             "name": "sebastian/exporter",
@@ -1797,7 +1797,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19T08:54:04+00:00"
+            "time": "2016-11-19 08:54:04"
         },
         {
             "name": "sebastian/global-state",
@@ -1848,7 +1848,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2015-10-12 03:26:01"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1894,7 +1894,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-11-19T07:35:10+00:00"
+            "time": "2016-11-19 07:35:10"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1947,7 +1947,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19T07:33:16+00:00"
+            "time": "2016-11-19 07:33:16"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1989,7 +1989,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2015-07-28 20:34:47"
         },
         {
             "name": "sebastian/version",
@@ -2032,7 +2032,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
+            "time": "2016-10-03 07:35:21"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -2110,7 +2110,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-02-02T03:30:00+00:00"
+            "time": "2017-02-02 03:30:00"
         },
         {
             "name": "symfony/console",
@@ -2173,7 +2173,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-06T12:04:21+00:00"
+            "time": "2017-02-06 12:04:21"
         },
         {
             "name": "symfony/debug",
@@ -2230,7 +2230,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-28T02:37:08+00:00"
+            "time": "2017-01-28 02:37:08"
         },
         {
             "name": "symfony/finder",
@@ -2279,7 +2279,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-02T20:32:22+00:00"
+            "time": "2017-01-02 20:32:22"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2338,62 +2338,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v3.2.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "e1718c6bf57e1efbb8793ada951584b2ab27775b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e1718c6bf57e1efbb8793ada951584b2ab27775b",
-                "reference": "e1718c6bf57e1efbb8793ada951584b2ab27775b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "symfony/console": "~2.8|~3.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2017-01-21T17:06:35+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "webmozart/assert",
@@ -2443,7 +2388,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2016-11-23 20:04:58"
         },
         {
             "name": "zendframework/zend-coding-standard",
@@ -2472,7 +2417,7 @@
                 "Coding Standard",
                 "zf"
             ],
-            "time": "2016-11-09T21:30:43+00:00"
+            "time": "2016-11-09 21:30:43"
         }
     ],
     "aliases": [],

--- a/src/GenerateProgrammaticPipelineFromConfig/Command.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Command.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/GenerateProgrammaticPipelineFromConfig/Command.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Command.php
@@ -67,7 +67,7 @@ class Command
         );
 
         try {
-            $generator = new Generator();
+            $generator = new Generator($this->console);
             $generator->projectDir = $this->projectDir;
             $generator->process($this->locateConfigFile($args));
         } catch (GeneratorException $e) {

--- a/src/GenerateProgrammaticPipelineFromConfig/Generator.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Generator.php
@@ -13,6 +13,7 @@ use Zend\Expressive\Application;
 use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
 use Zend\Expressive\Middleware\ImplicitOptionsMiddleware;
 use Zend\Expressive\Router\Route;
+use Zend\Stdlib\ConsoleHelper;
 use Zend\Stdlib\SplPriorityQueue;
 
 class Generator
@@ -90,9 +91,9 @@ EOT;
 EOT;
 
     // @codingStandardsIgnoreStart
-    const TEMPLATE_PIPELINE_NO_PATH = '$app->%s(%s);';
+    const TEMPLATE_PIPELINE_NO_PATH = '$app->pipe(%s);';
 
-    const TEMPLATE_PIPELINE_WITH_PATH = '$app->%s(%s, %s);';
+    const TEMPLATE_PIPELINE_WITH_PATH = '$app->pipe(%s, %s);';
 
     const TEMPLATE_ROUTED_METHOD_NO_NAME = '$app->%s(\'%s\', %s)';
 
@@ -111,6 +112,19 @@ EOT;
      * @var string Root path against which paths are relative.
      */
     public $projectDir = '.';
+
+    /**
+     * @var ConsoleHelper
+     */
+    private $console;
+
+    /**
+     * @param ConsoleHelper $console
+     */
+    public function __construct(ConsoleHelper $console)
+    {
+        $this->console = $console;
+    }
 
     /**
      * @param string $configFile
@@ -202,12 +216,10 @@ EOT;
                 $pipeline[] = '$app->pipeRoutingMiddleware();';
                 $pipeline[] = sprintf(
                     self::TEMPLATE_PIPELINE_NO_PATH,
-                    'pipe',
                     $this->formatMiddleware(ImplicitHeadMiddleware::class)
                 );
                 $pipeline[] = sprintf(
                     self::TEMPLATE_PIPELINE_NO_PATH,
-                    'pipe',
                     $this->formatMiddleware(ImplicitOptionsMiddleware::class)
                 );
                 continue;
@@ -223,11 +235,18 @@ EOT;
             $path       = isset($spec['path']) ? (string) $spec['path'] : null;
             $middleware = $this->formatMiddleware($spec['middleware']);
             $error      = isset($spec['error']) ? (bool) $spec['error'] : false;
-            $method     = $error ? 'pipeErrorHandler' : 'pipe';
+
+            if ($error) {
+                $this->console->writeLine(sprintf(
+                    '<error>Encountered error middleware "%s"; did not add to pipeline</error>',
+                    $middleware
+                ), true, STDERR);
+                continue;
+            }
 
             $pipeline[] = (null === $path)
-                ? sprintf(self::TEMPLATE_PIPELINE_NO_PATH, $method, $middleware)
-                : sprintf(self::TEMPLATE_PIPELINE_WITH_PATH, $method, $this->createOptionValue($path), $middleware);
+                ? sprintf(self::TEMPLATE_PIPELINE_NO_PATH, $middleware)
+                : sprintf(self::TEMPLATE_PIPELINE_WITH_PATH, $this->createOptionValue($path), $middleware);
         }
 
         // Push the original messages middleware and error handler to the top

--- a/src/GenerateProgrammaticPipelineFromConfig/Generator.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Generator.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/GenerateProgrammaticPipelineFromConfig/Generator.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Generator.php
@@ -31,7 +31,10 @@ class Generator
 
 use Zend\Expressive\Container\ErrorHandlerFactory;
 use Zend\Expressive\Container\ErrorResponseGeneratorFactory;
+use Zend\Expressive\Container\NotFoundDelegateFactory;
 use Zend\Expressive\Container\NotFoundHandlerFactory;
+use Zend\Expressive\Delegate\DefaultDelegate;
+use Zend\Expressive\Delegate\NotFoundDelegate;
 use Zend\Expressive\Middleware\ErrorResponseGenerator;
 use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
 use Zend\Expressive\Middleware\ImplicitOptionsMiddleware;
@@ -41,6 +44,10 @@ use Zend\Stratigility\Middleware\OriginalMessages;
 
 return [
     'dependencies' => [
+        'aliases' => [
+            // Override the following to provide an alternate default delegate.
+            DefaultDelegate::class => NotFoundDelegate::class,
+        ],
         'invokables' => [
             ImplicitHeadMiddleware::class => ImplicitHeadMiddleware::class,
             ImplicitOptionsMiddleware::class => ImplicitOptionsMiddleware::class,
@@ -52,6 +59,8 @@ return [
             // Zend\Expressive\Container\WhoopsErrorResponseGeneratorFactory
             // in order to use Whoops for development error handling.
             ErrorResponseGenerator::class => ErrorResponseGeneratorFactory::class,
+            // Override the following to use an alternate "not found" delegate.
+            NotFoundDelegate::class => NotFoundDelegateFactory::class,
             NotFoundHandler::class => NotFoundHandlerFactory::class,
         ],
     ],

--- a/test/GenerateProgrammaticPipelineFromConfig/CommandTest.php
+++ b/test/GenerateProgrammaticPipelineFromConfig/CommandTest.php
@@ -148,6 +148,13 @@ class CommandTest extends TestCase
             ->writeLine(Argument::containingString('defining the pipeline'))
             ->shouldBeCalled();
         $this->console
+            ->writeLine(
+                Argument::containingString('ErrorMiddleware'),
+                true,
+                STDERR
+            )
+            ->shouldBeCalled();
+        $this->console
             ->writeLine(Argument::containingString('defining the routes'))
             ->shouldBeCalled();
         $this->console

--- a/test/GenerateProgrammaticPipelineFromConfig/GeneratorTest.php
+++ b/test/GenerateProgrammaticPipelineFromConfig/GeneratorTest.php
@@ -10,8 +10,10 @@ namespace ZendTest\Expressive\Tooling\GenerateProgrammaticPipelineFromConfig;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Zend\Expressive\Tooling\GenerateProgrammaticPipelineFromConfig\Generator;
 use Zend\Expressive\Tooling\GenerateProgrammaticPipelineFromConfig\GeneratorException;
+use Zend\Stdlib\ConsoleHelper;
 
 class GeneratorTest extends TestCase
 {
@@ -24,7 +26,8 @@ class GeneratorTest extends TestCase
     public function setUp()
     {
         $this->dir = vfsStream::setup('project');
-        $this->generator = new Generator();
+        $this->console = $this->prophesize(ConsoleHelper::class);
+        $this->generator = new Generator($this->console->reveal());
         $this->generator->projectDir = vfsStream::url('project');
     }
 
@@ -45,6 +48,14 @@ class GeneratorTest extends TestCase
     public function testGeneratesExpectedPipeline()
     {
         $this->generatePipeline();
+
+        $this->console
+            ->writeLine(
+                Argument::containingString('ErrorMiddleware'),
+                true,
+                STDERR
+            )
+            ->shouldBeCalled();
 
         $configFile = vfsStream::url('project/config/config.php');
         $this->generator->process($configFile);

--- a/test/GenerateProgrammaticPipelineFromConfig/TestAsset/expected/config/autoload/programmatic-pipeline.global.php
+++ b/test/GenerateProgrammaticPipelineFromConfig/TestAsset/expected/config/autoload/programmatic-pipeline.global.php
@@ -5,7 +5,10 @@
 
 use Zend\Expressive\Container\ErrorHandlerFactory;
 use Zend\Expressive\Container\ErrorResponseGeneratorFactory;
+use Zend\Expressive\Container\NotFoundDelegateFactory;
 use Zend\Expressive\Container\NotFoundHandlerFactory;
+use Zend\Expressive\Delegate\DefaultDelegate;
+use Zend\Expressive\Delegate\NotFoundDelegate;
 use Zend\Expressive\Middleware\ErrorResponseGenerator;
 use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
 use Zend\Expressive\Middleware\ImplicitOptionsMiddleware;
@@ -15,6 +18,10 @@ use Zend\Stratigility\Middleware\OriginalMessages;
 
 return [
     'dependencies' => [
+        'aliases' => [
+            // Override the following to provide an alternate default delegate.
+            DefaultDelegate::class => NotFoundDelegate::class,
+        ],
         'invokables' => [
             ImplicitHeadMiddleware::class => ImplicitHeadMiddleware::class,
             ImplicitOptionsMiddleware::class => ImplicitOptionsMiddleware::class,
@@ -26,6 +33,8 @@ return [
             // Zend\Expressive\Container\WhoopsErrorResponseGeneratorFactory
             // in order to use Whoops for development error handling.
             ErrorResponseGenerator::class => ErrorResponseGeneratorFactory::class,
+            // Override the following to use an alternate "not found" delegate.
+            NotFoundDelegate::class => NotFoundDelegateFactory::class,
             NotFoundHandler::class => NotFoundHandlerFactory::class,
         ],
     ],

--- a/test/GenerateProgrammaticPipelineFromConfig/TestAsset/expected/config/pipeline.php
+++ b/test/GenerateProgrammaticPipelineFromConfig/TestAsset/expected/config/pipeline.php
@@ -20,5 +20,4 @@ $app->pipe(\Zend\Expressive\Middleware\ImplicitOptionsMiddleware::class);
 $app->pipe('Zend\\Expressive\\Helper\\UrlHelperMiddleware');
 $app->pipeDispatchMiddleware();
 $app->pipe('App\\Middleware\\NotFoundHandler');
-$app->pipeErrorHandler('App\\Middleware\\ErrorMiddleware');
 $app->pipe(\Zend\Expressive\Middleware\NotFoundHandler::class);


### PR DESCRIPTION
This patch updates the `experssive-pipeline-from-config` tooling as follows:

- It no longer generates `pipeErrorHandler()` statements; if any legacy error middleware specifications are encountered, it will emit an error message to STDOUT, and skip the definition.
- It now registers the `DefaultDelegate` and `NotFoundDelegate` services, with the former aliased to the latter.