### PR TITLE
Removed changing error reporting level in index.php

### DIFF
--- a/src/GenerateProgrammaticPipelineFromConfig/Generator.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Generator.php
@@ -83,11 +83,6 @@ EOT;
 
 EOT;
 
-    const TEMPLATE_PUBLIC_INDEX = <<< 'EOT'
-<?php
-error_reporting(error_reporting() & ~E_USER_DEPRECATED);
-EOT;
-
     const TEMPLATE_ROUTES = <<< 'EOT'
 <?php
 /**
@@ -503,8 +498,6 @@ EOT;
             . "require 'config/pipeline.php';\n"
             . "require 'config/routes.php';\n"
             . substr($application, $position);
-
-        $updated = str_replace('<' . '?php', self::TEMPLATE_PUBLIC_INDEX, $updated);
 
         file_put_contents($applicationPath, $updated);
     }

--- a/test/GenerateProgrammaticPipelineFromConfig/TestAsset/expected/public/index.php
+++ b/test/GenerateProgrammaticPipelineFromConfig/TestAsset/expected/public/index.php
@@ -1,5 +1,4 @@
 <?php
-error_reporting(error_reporting() & ~E_USER_DEPRECATED);
 
 // Delegate static file requests back to the PHP built-in webserver
 if (php_sapi_name() === 'cli-server'


### PR DESCRIPTION
It is no longer needed as Stratigility 2 and Expressive 2 do not emit any deprecation notices.