### PR TITLE
Fix conversion of routes without methods

### DIFF
--- a/src/GenerateProgrammaticPipelineFromConfig/Generator.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Generator.php
@@ -103,9 +103,9 @@ EOT;
 
     const TEMPLATE_ROUTED_METHOD_WITH_NAME = '$app->%s(\'%s\', %s, \'%s\')';
 
-    const TEMPLATE_ROUTED_NO_METHOD_NO_NAME = '$app->route(\'%s\', %s, \\Zend\\Expressive\\Router\\Route::HTTP_METHOD_ANY)';
+    const TEMPLATE_ROUTED_NO_METHOD_NO_NAME = '$app->route(\'%s\', %s, null)';
 
-    const TEMPLATE_ROUTED_NO_METHOD_WITH_NAME = '$app->route(\'%s\', %s, \\Zend\\Expressive\\Router\\Route::HTTP_METHOD_ANY, \'%s\')'; 
+    const TEMPLATE_ROUTED_NO_METHOD_WITH_NAME = '$app->route(\'%s\', %s, null, \'%s\')'; 
 
     const TEMPLATE_ROUTED_METHODS_NO_NAME = '$app->route(\'%s\', %s, %s)';
 

--- a/test/GenerateProgrammaticPipelineFromConfig/TestAsset/expected/config/routes.php
+++ b/test/GenerateProgrammaticPipelineFromConfig/TestAsset/expected/config/routes.php
@@ -16,7 +16,7 @@ $app->route('/rest/post', [
     'Api\\Middleware\\Negotiation',
     'Api\\Middleware\\Validation',
     'Api\\Action\\PostAction',
-], \Zend\Expressive\Router\Route::HTTP_METHOD_ANY, 'api.rest.post')
+], null, 'api.rest.post')
     ->setOptions([
         'sort' => 'updated',
         'order' => 'desc',


### PR DESCRIPTION
The `$methods` argument of `$app->route(...)` for no specific method is `null`, the generator is using `\Zend\Expressive\Router\Route::HTTP_METHOD_ANY` which is causing errors while converting.