### PR TITLE
New commands: expressive-create-middleware and metacommand "expressive"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.4.0 - TBD
+
+### Added
+
+- [#22](https://github.com/zendframework/zend-expressive-tooling/pull/22) adds
+  the command `expressive-create-middleware`, which allows creating an
+  http-interop middleware class file. The command expects a fully-qualified
+  class name, and will match the namespace against existing PSR-4 namespaces in
+  your `composer.json` in order to determine where to create the class file.
+
+- [#22](https://github.com/zendframework/zend-expressive-tooling/pull/22) adds
+  the metacommand `expressive`, which allows executing any of the other commands
+  provided in the package, minus their `expressive-` prefix. The command also
+  provides the ability to ask for individual command help using the syntax
+  `expressive help <command>` or `expressive <command> help`.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 0.3.2 - 2017-03-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ $ composer require --dev zendframework/zend-expressive-tooling
 
 ## Tools
 
+- `vendor/bin/expressive`: Meta-command for invoking all other commands. When
+  using this command, you can call any of the other commands minus the
+  `expressive-` prefix: e.g., `expressive module create Foo`. This command also
+  supports `help` operations of either the form `expressive help <command>` or
+  `expressive <command> help`.
+
+- `vendor/bin/expressive-create-middleware`: Create an http-interop middleware
+  class name; the class file is created based on matching a PSR-4 autoloader
+  defined in your `composer.json`.
+
 - `vendor/bin/expressive-migrate-original-messages`: Ensure your application
   does not use the Stratigility-specific PSR-7 message decorators.
 

--- a/bin/expressive
+++ b/bin/expressive
@@ -1,0 +1,27 @@
+#!/usr/bin/env php
+<?php // @codingStandardsIgnoreFile
+/**
+ * Wrapper for all other commands
+ *
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Tooling;
+
+use Zend\Stdlib\ConsoleHelper;
+
+// Setup/verify autoloading
+if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
+    require $a;
+} elseif (file_exists($a = __DIR__ . '/../vendor/autoload.php')) {
+    require $a;
+} else {
+    fwrite(STDERR, 'Cannot locate autoloader; please run "composer install"' . PHP_EOL);
+    exit(1);
+}
+
+$command = new ExpressiveCommand($argv[0], new ConsoleHelper());
+$return = $command->process(array_slice($argv, 1));
+exit($return);

--- a/bin/expressive-create-middleware
+++ b/bin/expressive-create-middleware
@@ -1,0 +1,27 @@
+#!/usr/bin/env php
+<?php // @codingStandardsIgnoreFile
+/**
+ * Script for creating PSR-15 middleware in a project
+ *
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Tooling\CreateMiddleware;
+
+use Zend\Stdlib\ConsoleHelper;
+
+// Setup/verify autoloading
+if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
+    require $a;
+} elseif (file_exists($a = __DIR__ . '/../vendor/autoload.php')) {
+    require $a;
+} else {
+    fwrite(STDERR, 'Cannot locate autoloader; please run "composer install"' . PHP_EOL);
+    exit(1);
+}
+
+$command = new Command($argv[0], new ConsoleHelper());
+$return = $command->process(array_slice($argv, 1));
+exit($return);

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
       }
     },
     "bin": [
+        "bin/expressive",
         "bin/expressive-create-middleware",
         "bin/expressive-migrate-original-messages",
         "bin/expressive-module",

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
       }
     },
     "bin": [
+        "bin/expressive-create-middleware",
         "bin/expressive-migrate-original-messages",
         "bin/expressive-module",
         "bin/expressive-pipeline-from-config",

--- a/src/CreateMiddleware/Command.php
+++ b/src/CreateMiddleware/Command.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Tooling\CreateMiddleware;
+
+use Zend\Stdlib\ConsoleHelper;
+
+class Command
+{
+    const DEFAULT_COMMAND_NAME = 'expressive-create-middleware';
+
+    public $projectDir = '.';
+
+    /**
+     * @var string
+     */
+    private $command;
+
+    /**
+     * @var array
+     */
+    private $helpArgs = ['--help', '-h', 'help'];
+
+    /**
+     * @var ConsoleHelper
+     */
+    private $console;
+
+    /**
+     * @param string $command Script that is invoking the command.
+     * @param null|ConsoleHelper $console
+     */
+    public function __construct($command = self::DEFAULT_COMMAND_NAME, ConsoleHelper $console = null)
+    {
+        $this->command = (string) $command;
+        $this->console = $console ?: new ConsoleHelper();
+    }
+
+    /**
+     * @param array $args
+     * @return int
+     */
+    public function process(array $args)
+    {
+        if ($this->isHelpRequest($args)) {
+            $help = new Help($this->command, $this->console);
+            $help(STDOUT);
+            return 0;
+        }
+
+        $args = $this->filterArgs($args);
+        $middleware = array_shift($args);
+
+        $this->console->writeLine(sprintf('<info>Creating middleware %s...</info>', $middleware));
+
+        $generator = new CreateMiddleware();
+
+        try {
+            $path = $generator->process($middleware, $this->projectDir);
+        } catch (CreateMiddlewareException $e) {
+            $this->console->writeLine('<error>Error during generation:</error>', true, STDERR);
+            $this->console->writeLine(sprintf('  <error>%s</error>', $e->getMessage()), true, STDERR);
+            return 1;
+        }
+
+        $this->console->writeLine('<info>Success!</info>');
+        $this->console->writeLine(sprintf(
+            '<info>- Created class %s, in file %s</info>',
+            $middleware,
+            $path
+        ));
+
+        return 0;
+    }
+
+    /**
+     * Is this a help request?
+     *
+     * @param array $args
+     * @return bool
+     */
+    private function isHelpRequest(array $args)
+    {
+        $numArgs = count($args);
+        if (0 === $numArgs) {
+            return true;
+        }
+
+        $arg = array_shift($args);
+
+        if (in_array($arg, $this->helpArgs, true)) {
+            return true;
+        }
+
+        if (empty($args)) {
+            return false;
+        }
+
+        $arg = array_shift($args);
+
+        return in_array($arg, $this->helpArgs, true);
+    }
+
+    /**
+     * @param array $args
+     * @return array
+     */
+    private function filterArgs(array $args)
+    {
+        return array_filter($args, function ($arg) {
+            return ! in_array($arg, $this->helpArgs, true);
+        });
+    }
+}

--- a/src/CreateMiddleware/CreateMiddleware.php
+++ b/src/CreateMiddleware/CreateMiddleware.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Tooling\CreateMiddleware;
+
+/**
+ * Create middleware
+ *
+ * Creates a middleware class file for a given class in a given project root.
+ */
+class CreateMiddleware
+{
+    /**
+     * @var string Template for middleware class.
+     */
+    const CLASS_SKELETON = <<< 'EOS'
+<?php
+
+namespace %namespace%;
+
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\ServerRequestInterface;
+
+class %class% implements MiddlewareInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    {
+        // $response = $delegate->process($request);
+    }
+}
+EOS;
+
+    /**
+     * @param string $class
+     * @param string $projectRoot
+     * @return string
+     * @throws CreateMiddlewareException
+     */
+    public function process($class, $projectRoot)
+    {
+        $path = $this->getClassPath($class, $projectRoot);
+
+        list($namespace, $class) = $this->getNamespaceAndClass($class);
+
+        $content = str_replace(
+            ['%namespace%', '%class%'],
+            [$namespace, $class],
+            self::CLASS_SKELETON
+        );
+
+        file_put_contents($path, $content);
+        return $path;
+    }
+
+    /**
+     * @param string $class
+     * @param string $projectRoot
+     * @return string
+     * @throws CreateMiddlewareException
+     */
+    private function getClassPath($class, $projectRoot)
+    {
+        $autoloaders = $this->getComposerAutoloaders($projectRoot);
+        list($namespace, $path) = $this->discoverNamespaceAndPath($class, $autoloaders);
+
+        // Absolute path to namespace
+        $path = implode([$projectRoot, DIRECTORY_SEPARATOR, $path]);
+
+        $parts = explode('\\', $class);
+        $className = array_pop($parts);
+
+        // Create absolute path to subnamespace, if required
+        $nsParts = explode('\\', trim($namespace, '\\'));
+        $subNsParts = array_slice($parts, count($nsParts));
+
+        if (0 < count($subNsParts)) {
+            $subNsPath = implode(DIRECTORY_SEPARATOR, $subNsParts);
+            $path = implode([$path, DIRECTORY_SEPARATOR, $subNsPath]);
+        }
+
+        // Create path if it does not exist
+        if (! is_dir($path)) {
+            if (false === mkdir($path, 0755, true)) {
+                throw CreateMiddlewareException::unableToCreatePath($path, $class);
+            }
+        }
+
+        return $path . DIRECTORY_SEPARATOR . $className . '.php';
+    }
+
+    /**
+     * @param string $projectRoot
+     * @return array Associative array of namespace/path pairs
+     * @throws CreateMiddlewareException
+     */
+    private function getComposerAutoloaders($projectRoot)
+    {
+        $composerPath = sprintf('%s/composer.json', $projectRoot);
+        if (! file_exists($composerPath)) {
+            throw CreateMiddlewareException::missingComposerJson();
+        }
+
+        $composer = json_decode(file_get_contents($composerPath), true);
+
+        if (json_last_error() !== \JSON_ERROR_NONE) {
+            throw CreateMiddlewareException::invalidComposerJson(json_last_error_msg());
+        }
+
+        if (! isset($composer['autoload']['psr-4'])) {
+            throw CreateMiddlewareException::missingComposerAutoloaders();
+        }
+
+        if (! is_array($composer['autoload']['psr-4'])) {
+            throw CreateMiddlewareException::missingComposerAutoloaders();
+        }
+
+        return $composer['autoload']['psr-4'];
+    }
+
+    /**
+     * @param string $class
+     * @param array $autoloaders
+     * @return array [namespace, path]
+     * @throws CreateMiddlewareException
+     */
+    private function discoverNamespaceAndPath($class, array $autoloaders)
+    {
+        $discoveredPath = false;
+        foreach ($autoloaders as $namespace => $path) {
+            if (0 === strpos($class, $namespace)) {
+                $path = trim(
+                    str_replace(
+                        ['/', '\\'],
+                        DIRECTORY_SEPARATOR,
+                        $path
+                    ),
+                    DIRECTORY_SEPARATOR
+                );
+                return [$namespace, $path];
+            }
+        }
+
+        throw CreateMiddlewareException::autoloaderNotFound($class);
+    }
+
+    /**
+     * @param string $class
+     * @return array [namespace, class]
+     */
+    private function getNamespaceAndClass($class)
+    {
+        $parts = explode('\\', $class);
+        $className = array_pop($parts);
+        $namespace = implode('\\', $parts);
+        return [$namespace, $className];
+    }
+}

--- a/src/CreateMiddleware/CreateMiddlewareException.php
+++ b/src/CreateMiddleware/CreateMiddlewareException.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Tooling\CreateMiddleware;
+
+use RuntimeException;
+
+class CreateMiddlewareException extends RuntimeException
+{
+    /**
+     * @return self
+     */
+    public static function missingComposerJson()
+    {
+        return new self('Could not find a composer.json in the project root');
+    }
+
+    /**
+     * @param string $error Error string related to JSON_ERROR_* constant
+     * @return self
+     */
+    public static function invalidComposerJson($error)
+    {
+        return new self(sprintf(
+            'Unable to parse composer.json: %s',
+            $error
+        ));
+    }
+
+    /**
+     * @return self
+     */
+    public static function missingComposerAutoloaders()
+    {
+        return new self('composer.json does not define any PSR-4 autoloaders');
+    }
+
+    /**
+     * @param string $class
+     * @return self
+     */
+    public static function autoloaderNotFound($class)
+    {
+        return new self(sprintf(
+            'Unable to match %s to an autoloadable PSR-4 namespace',
+            $class
+        ));
+    }
+
+    /**
+     * @param string $path
+     * @param string $class
+     * @return self
+     */
+    public static function unableToCreatePath($path, $class)
+    {
+        return new self(sprintf(
+            'Unable to create the directory %s for creating the class %s',
+            $path,
+            $class
+        ));
+    }
+}

--- a/src/CreateMiddleware/Help.php
+++ b/src/CreateMiddleware/Help.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Tooling\CreateMiddleware;
+
+use Zend\Stdlib\ConsoleHelper;
+
+class Help
+{
+    const TEMPLATE = <<< 'EOT'
+<info>Usage:</info>
+
+  %s [options] <middleware>
+
+<info>Arguments:</info>
+
+  <info>middleware</info>       Fully qualified class name of the middleware to create.
+                   This value should be quoted to ensure namespace separators
+                   are not interpreted as escape sequences by your shell.
+
+<info>Options:</info>
+
+  <info>--help|-h</info>        Display this help/usage message
+
+Creates an http-interop middleware class file named after the provided
+class. For a path, it matches the class namespace against PSR-4 autoloader
+namespaces in your composer.json.
+EOT;
+
+    /**
+     * @var string
+     */
+    private $command;
+
+    /**
+     * @var ConsoleHelper
+     */
+    private $helper;
+
+    /**
+     * @param string $command Name of script invoking the command.
+     * @param ConsoleHelper $helper
+     */
+    public function __construct($command, ConsoleHelper $helper)
+    {
+        $this->command = $command;
+        $this->helper = $helper;
+    }
+
+    /**
+     * Emit the help message.
+     *
+     * @param resource $resource Stream to which to write; defaults to STDOUT.
+     * @return void
+     */
+    public function __invoke($resource = STDOUT)
+    {
+        // Find relative command path
+        $command = strtr(realpath($this->command) ?: $this->command, [
+            getcwd() . DIRECTORY_SEPARATOR => '',
+            'zendframework' . DIRECTORY_SEPARATOR . 'zend-expressive-tooling' . DIRECTORY_SEPARATOR => '',
+        ]);
+
+        $this->helper->writeLine(sprintf(
+            self::TEMPLATE,
+            $command
+        ), true, $resource);
+    }
+}

--- a/src/ExpressiveCommand.php
+++ b/src/ExpressiveCommand.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Tooling;
+
+use Zend\Stdlib\ConsoleHelper;
+
+class ExpressiveCommand
+{
+    const DEFAULT_COMMAND_NAME = 'expressive';
+
+    public $projectDir = '.';
+
+    /**
+     * @var string
+     */
+    private $command;
+
+    /**
+     * @var ConsoleHelper
+     */
+    private $console;
+
+    /**
+     * @var string[]
+     */
+    private $helpArgs = ['--help', '-h', 'help'];
+
+    /**
+     * @var string[]
+     */
+    private $knownCommands = [
+        'create-middleware'         => CreateMiddleware\Command::class,
+        'migrate-original-messages' => MigrateOriginalMessageCalls\Command::class,
+        'module'                    => Module\Command::class,
+        'pipeline-from-config'      => GenerateProgrammaticPipelineFromConfig\Command::class,
+        'scan-for-error-middleware' => ScanForErrorMiddleware\Command::class,
+    ];
+
+    /**
+     * @param string $command Script that is invoking the command.
+     * @param ConsoleHelper $console
+     */
+    public function __construct($command = self::DEFAULT_COMMAND_NAME, ConsoleHelper $console = null)
+    {
+        $this->command = (string) $command;
+        $this->console = $console ?: new ConsoleHelper();
+    }
+
+    /**
+     * @param array $args
+     * @return int
+     */
+    public function process(array $args)
+    {
+        if ($this->isHelpRequest($args)) {
+            $help = new ExpressiveHelp($this->command, $this->console);
+            $help(STDOUT);
+            return 0;
+        }
+
+        $commandRequiringHelp = $this->discoverCommandHelpRequest($args);
+        if (false !== $commandRequiringHelp) {
+            return $this->dispatchCommand($commandRequiringHelp, ['help']);
+        }
+
+        try {
+            list($command, $commandArgs) = $this->discoverCommand($args);
+        } catch (InvalidCommandException $e) {
+            $this->console->writeLine('<error>Invalid command</error>', true, STDERR);
+            $help = new ExpressiveHelp($this->command, $this->console);
+            $help(STDERR);
+            return 1;
+        }
+
+        return $this->dispatchCommand($command, $commandArgs);
+    }
+
+    /**
+     * Is this a help request?
+     *
+     * @param array $args
+     * @return bool
+     */
+    private function isHelpRequest(array $args)
+    {
+        $numArgs = count($args);
+        if (0 === $numArgs) {
+            return true;
+        }
+
+        $arg = array_shift($args);
+
+        if (in_array($arg, $this->helpArgs, true) && empty($args)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array $args
+     * @return false|string String command name, if help request discovered
+     */
+    private function discoverCommandHelpRequest(array $args)
+    {
+        if (2 > count($args)) {
+            return false;
+        }
+
+        $first = array_shift($args);
+        $second = array_shift($args);
+
+        if (in_array($first, array_keys($this->knownCommands), true)
+            && in_array($second, $this->helpArgs, true)
+        ) {
+            return $first;
+        }
+
+        if (in_array($second, array_keys($this->knownCommands), true)
+            && in_array($first, $this->helpArgs, true)
+        ) {
+            return $second;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array $args
+     * @return array [command, array-of-arguments]
+     * @throws InvalidCommandException
+     */
+    private function discoverCommand(array $args)
+    {
+        $command = array_shift($args);
+
+        if (! in_array($command, array_keys($this->knownCommands), true)) {
+            throw new InvalidCommandException();
+        }
+
+        return [$command, $args];
+    }
+
+    /**
+     * @param string $command
+     * @param array $args
+     */
+    private function dispatchCommand($command, array $args)
+    {
+        $class = $this->knownCommands[$command];
+
+        $exec = new $class('expressive ' . $command, $this->console);
+        $exec->projectDir = $this->projectDir;
+
+        return $exec->process($args);
+    }
+}

--- a/src/ExpressiveHelp.php
+++ b/src/ExpressiveHelp.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Tooling;
+
+use Zend\Stdlib\ConsoleHelper;
+
+class ExpressiveHelp
+{
+    const TEMPLATE = <<< 'EOT'
+<info>Usage:</info>
+
+  %s <command>
+
+<info>Commands:</info>
+
+  <info>help</info>                         Display this help/usage message
+  <info>create-middleware</info>            Create a middleware class file
+  <info>migrate-original-messages</info>    Create a middleware class file
+  <info>module</info>                       Create, register, and deregister modules
+  <info>pipeline-from-config</info>         Create programmatic pipelines from config
+  <info>scan-for-error-middleware</info>    Scan for legacy error middleware
+
+You may also use:
+
+  %s help <command>
+
+in order to obtain help and options for any individual command.
+EOT;
+
+    /**
+     * @var string
+     */
+    private $command;
+
+    /**
+     * @var ConsoleHelper
+     */
+    private $helper;
+
+    /**
+     * @param string $command Name of script invoking the command.
+     * @param ConsoleHelper $helper
+     */
+    public function __construct($command, ConsoleHelper $helper)
+    {
+        $this->command = $command;
+        $this->helper = $helper;
+    }
+
+    /**
+     * Emit the help message.
+     *
+     * @param resource $resource Stream to which to write; defaults to STDOUT.
+     * @return void
+     */
+    public function __invoke($resource = STDOUT)
+    {
+        // Find relative command path
+        $command = strtr(realpath($this->command) ?: $this->command, [
+            getcwd() . DIRECTORY_SEPARATOR => '',
+            'zendframework' . DIRECTORY_SEPARATOR . 'zend-expressive-tooling' . DIRECTORY_SEPARATOR => '',
+        ]);
+
+        $this->helper->writeLine(sprintf(
+            self::TEMPLATE,
+            $command,
+            $command
+        ), true, $resource);
+    }
+}

--- a/src/InvalidCommandException.php
+++ b/src/InvalidCommandException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Tooling;
+
+use RuntimeException;
+
+class InvalidCommandException extends RuntimeException
+{
+}

--- a/src/Module/Command.php
+++ b/src/Module/Command.php
@@ -18,7 +18,7 @@ class Command
     /**
      * @var string
      */
-    private $projectDir = '.';
+    public $projectDir = '.';
 
     /**
      * @var string

--- a/test/CreateMiddleware/CommandTest.php
+++ b/test/CreateMiddleware/CommandTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Tooling\CreateMiddleware;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Zend\Expressive\Tooling\CreateMiddleware\Command;
+use Zend\Stdlib\ConsoleHelper;
+
+class CommandTest extends TestCase
+{
+    /** @var ConsoleHelper|\Prophecy\Prophecy\ObjectProphecy */
+    private $console;
+
+    protected function setUp()
+    {
+        $this->console = $this->prophesize(ConsoleHelper::class);
+        $this->command = new Command(Command::DEFAULT_COMMAND_NAME, $this->console->reveal());
+    }
+
+    public function helpArguments()
+    {
+        return [
+            'no-args'               => [[]],
+            'long-arg'              => [['--help']],
+            'short-arg'             => [['-h']],
+            'command'               => [['help']],
+            'long-arg-after-class'  => [[__CLASS__, '--help']],
+            'short-arg-after-class' => [[__CLASS__, '-h']],
+            'command-after-class'   => [[__CLASS__, 'help']],
+        ];
+    }
+
+    /**
+     * @dataProvider helpArguments
+     */
+    public function testHelpRequestsEmitHelp(array $args)
+    {
+        $this->console
+            ->writeLine(
+                Argument::containingString(Command::DEFAULT_COMMAND_NAME . ' [options] <middleware>'),
+                true,
+                STDOUT
+            )
+            ->shouldBeCalled();
+
+        $this->assertSame(0, $this->command->process($args));
+    }
+
+    public function testInvokingCommandWithInvalidSetupResultsInErrorMessage()
+    {
+        $dir = vfsStream::setup('project');
+        $projectRoot = vfsStream::url('project');
+        $this->command->projectDir = $projectRoot;
+
+        $this->console
+            ->writeLine(
+                Argument::containingString('Creating middleware Foo\BarMiddleware...')
+            )
+            ->shouldBeCalled();
+
+        $this->console
+            ->writeLine(
+                Argument::containingString('Error during generation'),
+                true,
+                STDERR
+            )
+            ->shouldBeCalled();
+
+        $this->console
+            ->writeLine(
+                Argument::containingString('composer.json'),
+                true,
+                STDERR
+            )
+            ->shouldBeCalled();
+
+        $this->assertSame(1, $this->command->process(['Foo\BarMiddleware']));
+    }
+
+    public function testSuccessfulInvocationResultsInSuccessStatus()
+    {
+        $dir = vfsStream::setup('project');
+        $projectRoot = vfsStream::url('project');
+        $this->command->projectDir = $projectRoot;
+        file_put_contents($projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'Foo\\' => 'src/Foo/',
+                ],
+            ],
+        ]));
+        vfsStream::newDirectory('src/Foo', 0775)->at($dir);
+
+        $this->console
+            ->writeLine(
+                Argument::containingString('Creating middleware Foo\BarMiddleware...')
+            )
+            ->shouldBeCalled();
+
+        $this->console
+            ->writeLine(
+                Argument::containingString('Success!')
+            )
+            ->shouldBeCalled();
+
+        $expectedPath = vfsStream::url('project/src/Foo/BarMiddleware.php');
+        $this->console
+            ->writeLine(
+                Argument::containingString('Created class Foo\BarMiddleware, in file ' . $expectedPath)
+            )
+            ->shouldBeCalled();
+
+        $this->assertSame(0, $this->command->process(['Foo\BarMiddleware']));
+        $this->assertFileExists($expectedPath);
+    }
+}

--- a/test/CreateMiddleware/CreateMiddlewareExceptionTest.php
+++ b/test/CreateMiddleware/CreateMiddlewareExceptionTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Tooling\CreateMiddleware;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Expressive\Tooling\CreateMiddleware\CreateMiddlewareException;
+
+class CreateMiddlewareExceptionTest extends TestCase
+{
+    public function testMissingComposerJsonReturnsInstance()
+    {
+        $e = CreateMiddlewareException::missingComposerJson();
+        $this->assertInstanceOf(CreateMiddlewareException::class, $e);
+        $this->assertContains('Could not find a composer.json', $e->getMessage());
+    }
+
+    public function testMissingComposerAutoloadersReturnsInstance()
+    {
+        $e = CreateMiddlewareException::missingComposerAutoloaders();
+        $this->assertInstanceOf(CreateMiddlewareException::class, $e);
+        $this->assertContains('PSR-4 autoloaders', $e->getMessage());
+    }
+
+    public function testInvalidComposerJsonReturnsInstanceWithErrorMessage()
+    {
+        $error = 'Invalid or malformed JSON';
+        $e = CreateMiddlewareException::invalidComposerJson($error);
+        $this->assertInstanceOf(CreateMiddlewareException::class, $e);
+        $this->assertContains('Unable to parse composer.json: ', $e->getMessage());
+        $this->assertContains($error, $e->getMessage());
+    }
+
+    public function testAutoloaderNotFoundReturnsInstanceUsingClassNameProvided()
+    {
+        $expected = __CLASS__;
+        $e = CreateMiddlewareException::autoloaderNotFound($expected);
+        $this->assertInstanceOf(CreateMiddlewareException::class, $e);
+        $this->assertContains('match ' . $expected, $e->getMessage());
+    }
+
+    public function testUnableToCreatePathReturnsInstanceUsingPathAndClassProvided()
+    {
+        $path = __FILE__;
+        $class = __CLASS__;
+        $e = CreateMiddlewareException::unableToCreatePath($path, $class);
+        $this->assertInstanceOf(CreateMiddlewareException::class, $e);
+        $this->assertContains('directory ' . $path, $e->getMessage());
+        $this->assertContains('class ' . $class, $e->getMessage());
+    }
+}

--- a/test/CreateMiddleware/CreateMiddlewareTest.php
+++ b/test/CreateMiddleware/CreateMiddlewareTest.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Tooling\CreateMiddleware;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\TestCase;
+use Zend\Expressive\Tooling\CreateMiddleware\CreateMiddleware;
+use Zend\Expressive\Tooling\CreateMiddleware\CreateMiddlewareException;
+
+class CreateMiddlewareTest extends TestCase
+{
+    /** @var vfsStreamDirectory */
+    private $dir;
+
+    /** @var string */
+    private $projectRoot;
+
+    public function setUp()
+    {
+        $this->dir = vfsStream::setup('project');
+        $this->projectRoot = vfsStream::url('project');
+    }
+
+    public function testProcessRaisesExceptionWhenComposerJsonNotPresentInProjectRoot()
+    {
+        $generator = new CreateMiddleware();
+
+        $this->expectException(CreateMiddlewareException::class);
+        $this->expectExceptionMessage('find a composer.json');
+
+        $generator->process('Foo\Bar\BazMiddleware', $this->projectRoot);
+    }
+
+    public function testProcessRaisesExceptionForMalformedComposerJson()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', 'not-a-value');
+        $generator = new CreateMiddleware();
+
+        $this->expectException(CreateMiddlewareException::class);
+        $this->expectExceptionMessage('Unable to parse');
+
+        $generator->process('Foo\Bar\BazMiddleware', $this->projectRoot);
+    }
+
+    public function testProcessRaisesExceptionIfComposerJsonDoesNotDefinePsr4Autoloaders()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode(['name' => 'some/project']));
+        $generator = new CreateMiddleware();
+
+        $this->expectException(CreateMiddlewareException::class);
+        $this->expectExceptionMessage('PSR-4 autoloaders');
+
+        $generator->process('Foo\Bar\BazMiddleware', $this->projectRoot);
+    }
+
+    public function testProcessRaisesExceptionIfComposerJsonDefinesMalformedPsr4Autoloaders()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => 'not-valid',
+            ],
+        ]));
+        $generator = new CreateMiddleware();
+
+        $this->expectException(CreateMiddlewareException::class);
+        $this->expectExceptionMessage('PSR-4 autoloaders');
+
+        $generator->process('Foo\Bar\BazMiddleware', $this->projectRoot);
+    }
+
+    public function testProcessRaisesExceptionIfClassDoesNotMatchAnyAutoloadableNamespaces()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/App/',
+                ],
+            ],
+        ]));
+        $generator = new CreateMiddleware();
+
+        $this->expectException(CreateMiddlewareException::class);
+        $this->expectExceptionMessage('Unable to match');
+
+        $generator->process('Foo\Bar\BazMiddleware', $this->projectRoot);
+    }
+
+    public function testProcessRaisesExceptionIfUnableToCreateSubPath()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/App/',
+                    'Foo\\' => 'src/Foo/src/',
+                ],
+            ],
+        ]));
+        vfsStream::newDirectory('src/Foo/src', 0555)->at($this->dir);
+
+        $generator = new CreateMiddleware();
+
+        $this->expectException(CreateMiddlewareException::class);
+        $this->expectExceptionMessage('Unable to create the directory');
+
+        $generator->process('Foo\Bar\BazMiddleware', $this->projectRoot);
+    }
+
+    public function testProcessCanCreateMiddlewareInNamespaceRoot()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/App/',
+                    'Foo\\' => 'src/Foo/',
+                ],
+            ],
+        ]));
+        vfsStream::newDirectory('src/Foo/src', 0775)->at($this->dir);
+
+        $generator = new CreateMiddleware();
+
+        $expectedPath = vfsStream::url('project/src/Foo/BarMiddleware.php');
+        $this->assertEquals(
+            $expectedPath,
+            $generator->process('Foo\BarMiddleware', $this->projectRoot)
+        );
+
+        $classFileContents = file_get_contents($expectedPath);
+        $this->assertRegexp('#^\<\?php#s', $classFileContents);
+        $this->assertRegexp('#^namespace Foo;$#m', $classFileContents);
+        $this->assertRegexp('#^class BarMiddleware implements MiddlewareInterface$#m', $classFileContents);
+        $this->assertRegexp(
+            '#^\s{4}public function process\(ServerRequestInterface \$request, DelegateInterface \$delegate\)$#m',
+            $classFileContents
+        );
+    }
+
+    public function testProcessCanCreateMiddlewareInSubNamespacePath()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/App/',
+                    'Foo\\' => 'src/Foo/',
+                ],
+            ],
+        ]));
+        vfsStream::newDirectory('src/Foo/src', 0775)->at($this->dir);
+
+        $generator = new CreateMiddleware();
+
+        $expectedPath = vfsStream::url('project/src/Foo/Bar/BazMiddleware.php');
+        $this->assertEquals(
+            $expectedPath,
+            $generator->process('Foo\Bar\BazMiddleware', $this->projectRoot)
+        );
+
+        $classFileContents = file_get_contents($expectedPath);
+        $this->assertRegexp('#^\<\?php#s', $classFileContents);
+        $this->assertRegexp('#^namespace Foo\\\\Bar;$#m', $classFileContents);
+        $this->assertRegexp('#^class BazMiddleware implements MiddlewareInterface$#m', $classFileContents);
+        $this->assertRegexp(
+            '#^\s{4}public function process\(ServerRequestInterface \$request, DelegateInterface \$delegate\)$#m',
+            $classFileContents
+        );
+    }
+
+    public function testProcessCanCreateMiddlewareInModuleNamespaceRoot()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/App/',
+                    'Foo\\' => 'src/Foo/src/',
+                ],
+            ],
+        ]));
+        vfsStream::newDirectory('src/Foo/src', 0775)->at($this->dir);
+
+        $generator = new CreateMiddleware();
+
+        $expectedPath = vfsStream::url('project/src/Foo/src/BarMiddleware.php');
+        $this->assertEquals(
+            $expectedPath,
+            $generator->process('Foo\BarMiddleware', $this->projectRoot)
+        );
+
+        $classFileContents = file_get_contents($expectedPath);
+        $this->assertRegexp('#^\<\?php#s', $classFileContents);
+        $this->assertRegexp('#^namespace Foo;$#m', $classFileContents);
+        $this->assertRegexp('#^class BarMiddleware implements MiddlewareInterface$#m', $classFileContents);
+        $this->assertRegexp(
+            '#^\s{4}public function process\(ServerRequestInterface \$request, DelegateInterface \$delegate\)$#m',
+            $classFileContents
+        );
+    }
+
+    public function testProcessCanCreateMiddlewareInModuleSubNamespacePath()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/App/',
+                    'Foo\\' => 'src/Foo/src/',
+                ],
+            ],
+        ]));
+        vfsStream::newDirectory('src/Foo/src', 0775)->at($this->dir);
+
+        $generator = new CreateMiddleware();
+
+        $expectedPath = vfsStream::url('project/src/Foo/src/Bar/BazMiddleware.php');
+        $this->assertEquals(
+            $expectedPath,
+            $generator->process('Foo\Bar\BazMiddleware', $this->projectRoot)
+        );
+
+        $classFileContents = file_get_contents($expectedPath);
+        $this->assertRegexp('#^\<\?php#s', $classFileContents);
+        $this->assertRegexp('#^namespace Foo\\\\Bar;$#m', $classFileContents);
+        $this->assertRegexp('#^class BazMiddleware implements MiddlewareInterface$#m', $classFileContents);
+        $this->assertRegexp(
+            '#^\s{4}public function process\(ServerRequestInterface \$request, DelegateInterface \$delegate\)$#m',
+            $classFileContents
+        );
+    }
+}

--- a/test/CreateMiddleware/HelpTest.php
+++ b/test/CreateMiddleware/HelpTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Tooling\CreateMiddleware;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Zend\Expressive\Tooling\CreateMiddleware\Help;
+use Zend\Stdlib\ConsoleHelper;
+
+class HelpTest extends TestCase
+{
+    public function testWritesHelpMessageToConsoleUsingCommandProvidedAtInstantiationAndResourceAtInvocation()
+    {
+        $resource = fopen('php://temp', 'wb+');
+
+        $console = $this->prophesize(ConsoleHelper::class);
+        $console
+            ->writeLine(
+                Argument::that(function ($message) {
+                    return false !== strpos($message, 'create-middleware');
+                }),
+                true,
+                $resource
+            )
+            ->shouldBeCalled();
+
+        $command = new Help(
+            'create-middleware',
+            $console->reveal()
+        );
+
+        $this->assertNull($command($resource));
+    }
+
+    public function testTruncatesCommandToBasenameIfItIsARealpath()
+    {
+        $resource = fopen('php://temp', 'wb+');
+
+        $console = $this->prophesize(ConsoleHelper::class);
+        $console
+            ->writeLine(
+                Argument::that(function ($message) {
+                    return false !== strpos($message, basename(__FILE__));
+                }),
+                true,
+                $resource
+            )
+            ->shouldBeCalled();
+
+        $command = new Help(
+            realpath(__FILE__),
+            $console->reveal()
+        );
+
+        $this->assertNull($command($resource));
+    }
+}

--- a/test/ExpressiveCommandTest.php
+++ b/test/ExpressiveCommandTest.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Tooling;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Zend\Expressive\Tooling\ExpressiveCommand;
+use Zend\Stdlib\ConsoleHelper;
+
+class ExpressiveCommandTest extends TestCase
+{
+    /** @var ConsoleHelper|\Prophecy\Prophecy\ObjectProphecy */
+    private $console;
+
+    protected function setUp()
+    {
+        $this->console = $this->prophesize(ConsoleHelper::class);
+        $this->command = new ExpressiveCommand(
+            ExpressiveCommand::DEFAULT_COMMAND_NAME,
+            $this->console->reveal()
+        );
+    }
+
+    public function helpArguments()
+    {
+        return [
+            'no-args'   => [[]],
+            'long-arg'  => [['--help']],
+            'short-arg' => [['-h']],
+            'command'   => [['help']],
+        ];
+    }
+
+    /**
+     * @dataProvider helpArguments
+     * @param array $args Arguments to pass to the command
+     */
+    public function testHelpRequestsEmitHelp(array $args)
+    {
+        $this->console
+            ->writeLine(
+                Argument::containingString(ExpressiveCommand::DEFAULT_COMMAND_NAME . ' <command>'),
+                true,
+                STDOUT
+            )
+            ->shouldBeCalled();
+
+        $this->assertSame(0, $this->command->process($args));
+    }
+
+    public function testPassingInvalidCommandEmitsErrorAndHelpToStderr()
+    {
+        $this->console
+            ->writeLine(
+                Argument::containingString('Invalid command'),
+                true,
+                STDERR
+            )
+            ->shouldBeCalled();
+        $this->console
+            ->writeLine(
+                Argument::containingString(ExpressiveCommand::DEFAULT_COMMAND_NAME . ' <command>'),
+                true,
+                STDERR
+            )
+            ->shouldBeCalled();
+
+        $this->assertSame(1, $this->command->process(['unknown-command']));
+    }
+
+    public function commandHelpArguments()
+    {
+        // @codingStandardsIgnoreStart
+        return [
+            'pre-create-middleware'          => [['help', 'create-middleware'], 'expressive create-middleware'],
+            'pre-migrate-original-messages'  => [['help', 'migrate-original-messages'], 'expressive migrate-original-messages'],
+            'pre-module'                     => [['help', 'module'], 'expressive module'],
+            'pre-pipeline-from-config'       => [['help', 'pipeline-from-config'], 'expressive pipeline-from-config'],
+            'pre-scan-for-error-middleware'  => [['help', 'scan-for-error-middleware'], 'expressive scan-for-error-middleware'],
+            'post-create-middleware'         => [['create-middleware', 'help'], 'create-middleware'],
+            'post-migrate-original-messages' => [['migrate-original-messages', 'help'], 'migrate-original-messages'],
+            'post-module'                    => [['module', 'help'], 'expressive module'],
+            'post-pipeline-from-config'      => [['pipeline-from-config', 'help'], 'expressive pipeline-from-config'],
+            'post-scan-for-error-middleware' => [['scan-for-error-middleware', 'help'], 'expressive scan-for-error-middleware'],
+        ];
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * @dataProvider commandHelpArguments
+     * @param array $args Arguments to pass to the command
+     * @param string $expected String to expect in console output
+     */
+    public function testCanRequestCommandHelp(array $args, $expected)
+    {
+        $this->console
+            ->writeLine(
+                Argument::containingString($expected),
+                true,
+                STDOUT
+            )
+            ->shouldBeCalled();
+
+        $this->assertSame(0, $this->command->process($args));
+    }
+
+    /**
+     * @todo Should likely test more commands. I've tested all of them manually,
+     *       but didn't want to set up tests for each of the current commands
+     *       due to testing complexity. They're likely fine, but we may run
+     *       against edge cases.
+     */
+    public function testCanDispatchKnownCommands()
+    {
+        $dir = vfsStream::setup('project');
+        $projectRoot = vfsStream::url('project');
+        $this->command->projectDir = $projectRoot;
+        file_put_contents($projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'Foo\\' => 'src/Foo/',
+                ],
+            ],
+        ]));
+        vfsStream::newDirectory('src/Foo', 0775)->at($dir);
+
+        $this->console
+            ->writeLine(
+                Argument::containingString('Creating middleware Foo\BarMiddleware...')
+            )
+            ->shouldBeCalled();
+
+        $this->console
+            ->writeLine(
+                Argument::containingString('Success!')
+            )
+            ->shouldBeCalled();
+
+        $expectedPath = vfsStream::url('project/src/Foo/BarMiddleware.php');
+        $this->console
+            ->writeLine(
+                Argument::containingString('Created class Foo\BarMiddleware, in file ' . $expectedPath)
+            )
+            ->shouldBeCalled();
+
+        $this->assertSame(0, $this->command->process(['create-middleware', 'Foo\BarMiddleware']));
+        $this->assertFileExists($expectedPath);
+    }
+}

--- a/test/ExpressiveHelpTest.php
+++ b/test/ExpressiveHelpTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Tooling;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Zend\Expressive\Tooling\ExpressiveHelp;
+use Zend\Stdlib\ConsoleHelper;
+
+class ExpressiveHelpTest extends TestCase
+{
+    public function testWritesHelpMessageToConsoleUsingCommandProvidedAtInstantiationAndResourceAtInvocation()
+    {
+        $resource = fopen('php://temp', 'wb+');
+
+        $console = $this->prophesize(ConsoleHelper::class);
+        $console
+            ->writeLine(
+                Argument::that(function ($message) {
+                    return false !== strpos($message, 'create-middleware');
+                }),
+                true,
+                $resource
+            )
+            ->shouldBeCalled();
+
+        $command = new ExpressiveHelp(
+            'expressive',
+            $console->reveal()
+        );
+
+        $this->assertNull($command($resource));
+    }
+
+    public function testTruncatesCommandToBasenameIfItIsARealpath()
+    {
+        $resource = fopen('php://temp', 'wb+');
+
+        $console = $this->prophesize(ConsoleHelper::class);
+        $console
+            ->writeLine(
+                Argument::that(function ($message) {
+                    return false !== strpos($message, basename(__FILE__));
+                }),
+                true,
+                $resource
+            )
+            ->shouldBeCalled();
+
+        $command = new ExpressiveHelp(
+            realpath(__FILE__),
+            $console->reveal()
+        );
+
+        $this->assertNull($command($resource));
+    }
+}


### PR DESCRIPTION
This adds a new command, `expressive-create-middleware`, which allows you to create a PSR-15 middleware classfile for the provided fully-qualified class name:

```bash
$ ./vendor/bin/expressive-create-middleware "Foo\BarMiddleware"
```

It will create it in a directory based on matching the namespace of the requested class against defined PSR-4 autoloaders for the current project.

This patch also creates the metacommand `expressive`, which allows you to invoke all other commands in this project:

```bash
$ ./vendor/bin/expressive module create Foo
$ ./vendor/bin/expressive create-middleware "Foo\BarMiddleware"
```

When invoked with no arguments or a `help` argument, it lists available commands. It also allows you to access help for individual commands using the syntax `expressive help <command>`.