### PR TITLE
Fixed incorrect use statement

### DIFF
--- a/src/CreateMiddleware/CreateMiddleware.php
+++ b/src/CreateMiddleware/CreateMiddleware.php
@@ -24,7 +24,7 @@ namespace %namespace%;
 
 use Interop\Http\ServerMiddleware\DelegateInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
-use Psr\Http\ServerRequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 class %class% implements MiddlewareInterface
 {


### PR DESCRIPTION
When using the middleware:create command, the generated middleware contains an incorrect use statement. This PR fixes it