### PR TITLE
Updated symfony/console required version to be less restrictive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "symfony/console": "^3.2.7",
+        "symfony/console": "^3.0 || ^2.8",
         "zendframework/zend-code": "^3.1 || ^2.6.3",
         "zendframework/zend-component-installer": "^0.7.1",
         "zendframework/zend-expressive": "^2.0 || dev-2.0.X@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "22072d167d0ad7805c45beaf01424014",
+    "content-hash": "66eb193cb35a93d0e78356e1406a3bc1",
     "packages": [
         {
             "name": "fig/http-message-util",


### PR DESCRIPTION
I have tested that all commands keep working with symfony/console 2.8, 3.0 and 3.1, as well as 3.2, so I have changed the required version to `^3.0 || ^2.8`.

I think this is important, since symfony/console is a widely used component, and being too restrictive could cause version conflicts.

Also, symfony 3.3 is going to be released soon, and requiring `^3.2.7` will conflict with users that want to use it.

I haven't added tests because of the way travis is configured. As far as I see, tests are already being run against different dependency versions and passing.