### PR TITLE
fix autoload bump version

### DIFF
--- a/bin/bump-version
+++ b/bin/bump-version
@@ -15,7 +15,15 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-require __DIR__ . '/../vendor/autoload.php';
+// Setup/verify autoloading
+if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
+    require $a;
+} elseif (file_exists($a = __DIR__ . '/../vendor/autoload.php')) {
+    require $a;
+} else {
+    fwrite(STDERR, 'Cannot locate autoloader; please run "composer install"' . PHP_EOL);
+    exit(1);
+}
 
 $app = new Application('bump-version');
 


### PR DESCRIPTION
Hello, @weierophinney, @xtreamwayz
Can you check this ? 
This fix allows bump-version to find the right autoload file.
According the doc on this part [CONTRIBUTING#releases](https://github.com/zendframework/zend-expressive-tooling/blob/master/CONTRIBUTING.md#releases).
Don't forget to execute this file while preparing your realase.
```
php vendor/zendframework/zend-expressive-tooling/bin/bump-version to 0.4.4
```