### PR TITLE
Added another path option to reach Composer autoload.php.

### DIFF
--- a/bin/expressive
+++ b/bin/expressive
@@ -19,6 +19,8 @@ if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
     require $a;
 } elseif (file_exists($a = __DIR__ . '/../vendor/autoload.php')) {
     require $a;
+} elseif (file_exists($a = __DIR__ . '/../autoload.php')) {
+    require $a;
 } else {
     fwrite(STDERR, 'Cannot locate autoloader; please run "composer install"' . PHP_EOL);
     exit(1);


### PR DESCRIPTION
Added another path option in order for script to reach Composer's autoload.php when issuing a command while using zend-expressive-skeleton from root directory. As per the documentation at https://docs.zendframework.com/zend-expressive/reference/cli-tooling/