### PR TITLE
Allow overriding the class skeleton

### DIFF
--- a/src/CreateMiddleware/CreateMiddleware.php
+++ b/src/CreateMiddleware/CreateMiddleware.php
@@ -45,7 +45,7 @@ EOS;
      * @return string
      * @throws CreateMiddlewareException
      */
-    public function process($class, $projectRoot = null, $classSkeleton = null)
+    public function process($class, $projectRoot = null, $classSkeleton = self::CLASS_SKELETON)
     {
         $projectRoot = $projectRoot ?: getcwd();
 
@@ -56,7 +56,7 @@ EOS;
         $content = str_replace(
             ['%namespace%', '%class%'],
             [$namespace, $class],
-            $classSkeleton ?: self::CLASS_SKELETON
+            $classSkeleton
         );
 
         if (is_file($path)) {

--- a/src/CreateMiddleware/CreateMiddleware.php
+++ b/src/CreateMiddleware/CreateMiddleware.php
@@ -41,7 +41,7 @@ EOS;
     /**
      * @param string $class
      * @param string|null $projectRoot
-     * @param string|null $classSkeleton
+     * @param string $classSkeleton
      * @return string
      * @throws CreateMiddlewareException
      */

--- a/src/CreateMiddleware/CreateMiddleware.php
+++ b/src/CreateMiddleware/CreateMiddleware.php
@@ -139,7 +139,6 @@ EOS;
      */
     private function discoverNamespaceAndPath($class, array $autoloaders)
     {
-        $discoveredPath = false;
         foreach ($autoloaders as $namespace => $path) {
             if (0 === strpos($class, $namespace)) {
                 $path = trim(

--- a/src/CreateMiddleware/CreateMiddleware.php
+++ b/src/CreateMiddleware/CreateMiddleware.php
@@ -41,10 +41,11 @@ EOS;
     /**
      * @param string $class
      * @param string|null $projectRoot
+     * @param string|null $classSkeleton
      * @return string
      * @throws CreateMiddlewareException
      */
-    public function process($class, $projectRoot = null)
+    public function process($class, $projectRoot = null, $classSkeleton = null)
     {
         $projectRoot = $projectRoot ?: getcwd();
 
@@ -55,7 +56,7 @@ EOS;
         $content = str_replace(
             ['%namespace%', '%class%'],
             [$namespace, $class],
-            self::CLASS_SKELETON
+            $classSkeleton !== null ? $classSkeleton : self::CLASS_SKELETON
         );
 
         if (is_file($path)) {

--- a/src/CreateMiddleware/CreateMiddleware.php
+++ b/src/CreateMiddleware/CreateMiddleware.php
@@ -58,6 +58,10 @@ EOS;
             self::CLASS_SKELETON
         );
 
+        if (is_file($path)) {
+            throw CreateMiddlewareException::classExists($path, $class);
+        }
+
         file_put_contents($path, $content);
         return $path;
     }

--- a/src/CreateMiddleware/CreateMiddleware.php
+++ b/src/CreateMiddleware/CreateMiddleware.php
@@ -56,7 +56,7 @@ EOS;
         $content = str_replace(
             ['%namespace%', '%class%'],
             [$namespace, $class],
-            $classSkeleton !== null ? $classSkeleton : self::CLASS_SKELETON
+            $classSkeleton ?: self::CLASS_SKELETON
         );
 
         if (is_file($path)) {

--- a/src/CreateMiddleware/CreateMiddlewareException.php
+++ b/src/CreateMiddleware/CreateMiddlewareException.php
@@ -64,4 +64,18 @@ class CreateMiddlewareException extends RuntimeException
             $class
         ));
     }
+
+    /**
+     * @param string $path
+     * @param string $class
+     * @return self
+     */
+    public static function classExists($path, $class)
+    {
+        return new self(sprintf(
+            'Class %s already exists in directory %s',
+            $class,
+            $path
+        ));
+    }
 }

--- a/src/GenerateProgrammaticPipelineFromConfig/Generator.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Generator.php
@@ -119,6 +119,7 @@ EOT;
 
     /**
      * @param OutputInterface $console
+     * @param string $projectDir
      */
     public function __construct(OutputInterface $console, $projectDir = '.')
     {

--- a/src/Module/CommandCommonOptions.php
+++ b/src/Module/CommandCommonOptions.php
@@ -19,6 +19,8 @@ final class CommandCommonOptions
 {
     /**
      * Add default arguments and options used by all commands.
+     *
+     * @param Command $command
      */
     public static function addDefaultOptionsAndArguments(Command $command)
     {

--- a/test/CreateMiddleware/CreateMiddlewareExceptionTest.php
+++ b/test/CreateMiddleware/CreateMiddlewareExceptionTest.php
@@ -52,4 +52,14 @@ class CreateMiddlewareExceptionTest extends TestCase
         $this->assertContains('directory ' . $path, $e->getMessage());
         $this->assertContains('class ' . $class, $e->getMessage());
     }
+
+    public function testClassExistsReturnsInstanceUsingPathAndClassProvided()
+    {
+        $path = __FILE__;
+        $class = __CLASS__;
+        $e = CreateMiddlewareException::classExists($path, $class);
+        $this->assertInstanceOf(CreateMiddlewareException::class, $e);
+        $this->assertContains('directory ' . $path, $e->getMessage());
+        $this->assertContains('Class ' . $class, $e->getMessage());
+    }
 }

--- a/test/CreateMiddleware/CreateMiddlewareTest.php
+++ b/test/CreateMiddleware/CreateMiddlewareTest.php
@@ -230,4 +230,25 @@ class CreateMiddlewareTest extends TestCase
             $classFileContents
         );
     }
+
+    public function testProcessThrowsExceptionIfClassAlreadyExists()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/App/',
+                ],
+            ],
+        ]));
+
+        vfsStream::newDirectory('src/App/Foo', 0775)->at($this->dir);
+        file_put_contents($this->projectRoot . '/src/App/Foo/BarMiddleware.php', 'App\Foo\BarMiddleware');
+
+        $generator = new CreateMiddleware();
+
+        $this->expectException(CreateMiddlewareException::class);
+        $this->expectExceptionMessage('Class BarMiddleware already exists');
+
+        $generator->process('App\Foo\BarMiddleware', $this->projectRoot);
+    }
 }

--- a/test/CreateMiddleware/CreateMiddlewareTest.php
+++ b/test/CreateMiddleware/CreateMiddlewareTest.php
@@ -251,4 +251,28 @@ class CreateMiddlewareTest extends TestCase
 
         $generator->process('App\Foo\BarMiddleware', $this->projectRoot);
     }
+
+    public function testTheClassSkeletonParameterOverridesTheConstant()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/App/',
+                    'Foo\\' => 'src/Foo/',
+                ],
+            ],
+        ]));
+        vfsStream::newDirectory('src/Foo/src', 0775)->at($this->dir);
+
+        $generator = new CreateMiddleware();
+
+        $expectedPath = vfsStream::url('project/src/Foo/Bar/BazMiddleware.php');
+        $this->assertEquals(
+            $expectedPath,
+            $generator->process('Foo\Bar\BazMiddleware', $this->projectRoot, 'class Foo\Bar\BazMiddleware')
+        );
+
+        $classFileContents = file_get_contents($expectedPath);
+        $this->assertContains('class Foo\Bar\BazMiddleware', $classFileContents);
+    }
 }


### PR DESCRIPTION
This adds the ability to override the CLASS_SKELETON constant. Ideally you create your own command and pass your custom class skeleton in the process method.

Build on top of #31.