### PR TITLE
PSR-15 support (http-interop/http-server-middleware)

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,5 +1,7 @@
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,68 +5,44 @@ language: php
 cache:
   directories:
     - $HOME/.composer/cache
-    - vendor
 
 env:
   global:
     - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="satooshi/php-coveralls"
-    - LEGACY_DEPS="phpunit/phpunit php-mock/php-mock-phpunit"
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.1
       env:
         - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=locked
-        - TEST_COVERAGE=true
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
+    - php: 7.1
       env:
         - DEPS=locked
         - CS_CHECK=true
-    - php: 7
+        - TEST_COVERAGE=true
+    - php: 7.1
       env:
         - DEPS=latest
-    - php: 7.1
+    - php: 7.2
       env:
         - DEPS=lowest
-    - php: 7.1
+    - php: 7.2
       env:
         - DEPS=locked
-    - php: 7.1
+    - php: 7.2
       env:
         - DEPS=latest
-    - php: hhvm
-      env:
-        - DEPS=lowest
-    - php: hhvm
-      env:
-        - DEPS=locked
-    - php: hhvm
-      env:
-        - DEPS=latest
-  allow_failures:
-    - php: hhvm
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - travis_retry composer self-update
 
 install:
-  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
-  - if [[ $TRAVIS_PHP_VERSION =~ ^5.6 ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
+  - travis_retry composer install $COMPOSER_ARGS
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
-  - composer show
+  - stty cols 120 && composer show
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
@@ -74,17 +50,7 @@ script:
   - if [[ $CS_CHECK == 'true' ]]; then composer license-check ; fi
 
 after_script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer upload-coverage ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer upload-coverage ; fi
 
 notifications:
   email: false
-  irc:
-    channels:
-      - "irc.freenode.org#zftalk.dev"
-    on_success: change
-    on_failure: always
-  slack:
-    rooms:
-      - secure: "GS3+RkDETX42GrjKMJNQy/JJZYJawBgcOIMJZHQS0xdv2DbnEE21z/sn3d+AV10CqCicovcCjYPKgQH/aSDI2dNJf1ZnqvM5JICDl9TjBkEQC/xybm645iy0NpgC2T8yuL56agz20fsDONt+vA05X9Ytm8z+Ipy0uKXYrrsL0FlpEStaTeG3z2wk/5cww93tKLcg6QLRa6AeensrAEiz+hvNWu0OR7pEziY28tC+4F5KlZIE0s8TkJ5TZ6pvZ7pcwpK+mtxlmkOKVN93QcvBRjd1xuuRHOHN7Pmp5CiIYbTQTzruF2l1R7bnVVgfeXgWqJOxy0lH3H1gQDqj3fo7uHjm2Zg4Hr0Ev22dFM19N9+SIAELUpDoHNnuhJ/o6fpNd9VQVSgeki8YzNwJrhX5gnFtLV/4wyrmsRxdpKdtxoSINu5HyklamKiVRmbQaIuOPw1NQkOAYL4vHQIwjuwcn8YQArCwwvO4vh3yBQo0mtT9BbkajJ5R118F6jUIOYe9BVFicf+xyrVwCfxziq+jqPOHmtF7Oeb4jRASzTAZsIIVe7TkuckFCNqpRiBmNkbHOU4fZiNfGfPhsx9u0uEoD7tnurx4XFA5Xa2xnBOMQd3ZIAFGtMipnHfIgnEZ9IVNnQZv9q5Fs8/EH5MsR5GJpihEJOGKBn1E/i2mOfE+EsU="
-    on_success: change
-    on_failure: always

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ $ composer require --dev zendframework/zend-expressive-tooling
   - **middleware:create**: Create an http-interop middleware class file.
   - **migrate:error-middleware-scanner**: Scan for legacy error middleware or
     error middleware invocation.
+  - **migrate:interop-middleware**: Migrate interop middlewares and delegators
+    to PSR-15 middlewares and request handlers.
   - **migrate:original-messages**: Migrate getOriginal*() calls to request
     attributes.
   - **migrate:pipeline**: Generate a programmatic pipeline and routes from

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -8,6 +8,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -4,7 +4,7 @@
  * Command for bumping the VERSION constants of all scripts.
  *
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/bin/expressive
+++ b/bin/expressive
@@ -4,7 +4,7 @@
  * Wrapper for all other commands
  *
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/bin/expressive
+++ b/bin/expressive
@@ -30,6 +30,7 @@ $application = new Application('expressive', VERSION);
 $application->addCommands([
     new CreateMiddleware\CreateMiddlewareCommand('middleware:create'),
     new GenerateProgrammaticPipelineFromConfig\PipelineFromConfigCommand('migrate:pipeline'),
+    new MigrateInteropMiddleware\MigrateInteropMiddlewareCommand('migrate:interop-middleware'),
     new MigrateOriginalMessageCalls\MigrateOriginalMessageCallsCommand('migrate:original-messages'),
     new ScanForErrorMiddleware\ScanForErrorMiddlewareCommand('migrate:error-middleware-scanner'),
     new Module\CreateCommand('module:create'),

--- a/bin/expressive
+++ b/bin/expressive
@@ -8,6 +8,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling;
 
 use Symfony\Component\Console\Application;

--- a/bin/expressive-migrate-original-messages
+++ b/bin/expressive-migrate-original-messages
@@ -8,6 +8,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\MigrateOriginalMessageCalls;
 
 use Symfony\Component\Console\Application;

--- a/bin/expressive-migrate-original-messages
+++ b/bin/expressive-migrate-original-messages
@@ -4,7 +4,7 @@
  * Script for updating calls to Stragitiligy PSR-7 decorators to usage of request attributes.
  *
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/bin/expressive-module
+++ b/bin/expressive-module
@@ -4,7 +4,7 @@
  * Script for deal with expressive modules.
  *
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/bin/expressive-module
+++ b/bin/expressive-module
@@ -8,6 +8,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\Module;
 
 use Symfony\Component\Console\Application;

--- a/bin/expressive-pipeline-from-config
+++ b/bin/expressive-pipeline-from-config
@@ -4,7 +4,7 @@
  * Script for migrating configuration-driven pipelines/routes to programmatic usage.
  *
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/bin/expressive-pipeline-from-config
+++ b/bin/expressive-pipeline-from-config
@@ -8,6 +8,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\GenerateProgrammaticPipelineFromConfig;
 
 use Symfony\Component\Console\Application;

--- a/bin/expressive-scan-for-error-middleware
+++ b/bin/expressive-scan-for-error-middleware
@@ -4,7 +4,7 @@
  * Script that scans for error middleware implementations and invocations
  *
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/bin/expressive-scan-for-error-middleware
+++ b/bin/expressive-scan-for-error-middleware
@@ -8,6 +8,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\ScanForErrorMiddleware;
 
 use Symfony\Component\Console\Application;

--- a/composer.json
+++ b/composer.json
@@ -20,26 +20,18 @@
     "repositories": [
         {
             "type": "git",
-            "url": "https://github.com/webimpress/zend-expressive-router.git"
-        },
-        {
-            "type": "git",
             "url": "https://github.com/webimpress/zend-expressive.git"
-        },
-        {
-            "type": "git",
-            "url": "https://github.com/webimpress/zend-stratigility.git"
         }
     ],
     "require": {
         "php": "^7.1",
-        "symfony/console": "^2.8 || ^3.0",
+        "symfony/console": "^2.8 || ^3.0 || ^4.0",
         "zendframework/zend-code": "^2.6.3 || ^3.3",
         "zendframework/zend-component-installer": "^1.1",
-        "zendframework/zend-expressive": "dev-feature/psr-15 as 2.2",
-        "zendframework/zend-expressive-router": "dev-feature/psr-15 as 2.2",
+        "zendframework/zend-expressive": "dev-feature/psr-15 as 3.0",
+        "zendframework/zend-expressive-router": "^3.0.0-dev",
         "zendframework/zend-stdlib": "^3.1",
-        "zendframework/zend-stratigility": "dev-feature/psr-15 as 2.2",
+        "zendframework/zend-stratigility": "^3.0.0-dev",
         "zfcampus/zf-composer-autoloading": "^2.0"
     },
     "require-dev": {
@@ -47,7 +39,7 @@
         "mikey179/vfsStream": "^1.6.5",
         "mockery/mockery": "^1.0",
         "php-mock/php-mock-phpunit": "^2.0",
-        "phpunit/phpunit": "^6.4.4",
+        "phpunit/phpunit": "^6.4.4, <6.5",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,22 +17,37 @@
             "dev-master": "1.0-dev"
         }
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-expressive-router.git"
+        },
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-expressive.git"
+        },
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-stratigility.git"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
-        "symfony/console": "^3.0 || ^2.8",
-        "zendframework/zend-code": "^3.1 || ^2.6.3",
-        "zendframework/zend-component-installer": "^1.0 || ^0.7.1",
-        "zendframework/zend-expressive": "^2.0",
+        "php": "^7.1",
+        "symfony/console": "^2.8 || ^3.0",
+        "zendframework/zend-code": "^2.6.3 || ^3.3",
+        "zendframework/zend-component-installer": "^1.1",
+        "zendframework/zend-expressive": "dev-feature/psr-15 as 2.2",
+        "zendframework/zend-expressive-router": "dev-feature/psr-15 as 2.2",
         "zendframework/zend-stdlib": "^3.1",
-        "zendframework/zend-stratigility": "^2.0",
+        "zendframework/zend-stratigility": "dev-feature/psr-15 as 2.2",
         "zfcampus/zf-composer-autoloading": "^2.0"
     },
     "require-dev": {
-        "malukenho/docheader": "^0.1.5",
-        "mikey179/vfsStream": "^1.6.4",
-        "mockery/mockery": "^0.9.8",
-        "php-mock/php-mock-phpunit": "^2.0 || ^1.1.2",
-        "phpunit/phpunit": "^6.0.7 || ^5.7.14",
+        "malukenho/docheader": "^0.1.6",
+        "mikey179/vfsStream": "^1.6.5",
+        "mockery/mockery": "^1.0",
+        "php-mock/php-mock-phpunit": "^2.0",
+        "phpunit/phpunit": "^6.4.4",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c37c4b3b10259cd0645cb8392e2b262f",
+    "content-hash": "037f166e0c8da19dd34db9abc6a27389",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -311,44 +311,45 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.3.13",
+            "version": "v3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "63cd7960a0a522c3537f6326706d7f3b8de65805"
+                "reference": "2cdef78de8f54f68ff16a857e710e7302b47d4c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/63cd7960a0a522c3537f6326706d7f3b8de65805",
-                "reference": "63cd7960a0a522c3537f6326706d7f3b8de65805",
+                "url": "https://api.github.com/repos/symfony/console/zipball/2cdef78de8f54f68ff16a857e710e7302b47d4c7",
+                "reference": "2cdef78de8f54f68ff16a857e710e7302b47d4c7",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.5.9|>=7.0.8",
-                "symfony/debug": "~2.8|~3.0",
+                "symfony/debug": "~2.8|~3.0|~4.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.3"
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.3",
-                "symfony/dependency-injection": "~3.3",
-                "symfony/event-dispatcher": "~2.8|~3.0",
-                "symfony/filesystem": "~2.8|~3.0",
-                "symfony/process": "~2.8|~3.0"
+                "symfony/config": "~3.3|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.3|~4.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
-                "symfony/filesystem": "",
+                "symfony/lock": "",
                 "symfony/process": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -375,36 +376,36 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-16T15:24:32+00:00"
+            "time": "2017-12-02T18:20:11+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.3.13",
+            "version": "v4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "74557880e2846b5c84029faa96b834da37e29810"
+                "reference": "26a15dab86c3820473716be4f846eac774ad4ad9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/74557880e2846b5c84029faa96b834da37e29810",
-                "reference": "74557880e2846b5c84029faa96b834da37e29810",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/26a15dab86c3820473716be4f846eac774ad4ad9",
+                "reference": "26a15dab86c3820473716be4f846eac774ad4ad9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": "^7.1.3",
                 "psr/log": "~1.0"
             },
             "conflict": {
-                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
+                "symfony/http-kernel": "<3.4"
             },
             "require-dev": {
-                "symfony/http-kernel": "~2.8|~3.0"
+                "symfony/http-kernel": "~3.4|~4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -431,7 +432,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-10T16:38:39+00:00"
+            "time": "2017-11-21T09:27:49+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -753,7 +754,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/zend-expressive.git",
-                "reference": "1bf07dd1afe04e23265bd735e32ddc478e88933a"
+                "reference": "16bb652f75410b3d26774753b5c7580f0c7c4878"
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
@@ -762,9 +763,9 @@
                 "psr/container": "^1.0",
                 "psr/http-message": "^1.0.1",
                 "zendframework/zend-diactoros": "^1.3.10",
-                "zendframework/zend-expressive-router": "dev-feature/psr-15 as 2.2",
+                "zendframework/zend-expressive-router": "^3.0.0-dev",
                 "zendframework/zend-expressive-template": "^1.0.4",
-                "zendframework/zend-stratigility": "dev-feature/psr-15 as 2.2"
+                "zendframework/zend-stratigility": "^3.0.0-dev"
             },
             "conflict": {
                 "container-interop/container-interop": "<1.2.0"
@@ -773,11 +774,11 @@
                 "filp/whoops": "^1.1.10 || ^2.1.13",
                 "malukenho/docheader": "^0.1.6",
                 "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^6.4.4",
+                "phpunit/phpunit": "^6.5.3",
                 "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-expressive-aurarouter": "^2.0",
-                "zendframework/zend-expressive-fastroute": "^2.0",
-                "zendframework/zend-expressive-zendrouter": "^2.0.1",
+                "zendframework/zend-expressive-aurarouter": "^3.0.0-dev",
+                "zendframework/zend-expressive-fastroute": "^3.0.0-dev",
+                "zendframework/zend-expressive-zendrouter": "^3.0.0-dev",
                 "zendframework/zend-servicemanager": "^2.7.8 || ^3.3"
             },
             "suggest": {
@@ -840,13 +841,15 @@
                 "BSD-3-Clause"
             ],
             "description": "PSR-7 Middleware Microframework based on Stratigility",
-            "homepage": "https://docs.zendframework.com/zend-expressive/",
             "keywords": [
+                "expressive",
                 "http",
                 "middleware",
                 "psr",
                 "psr-11",
-                "psr-7"
+                "psr-7",
+                "zendframework",
+                "zf"
             ],
             "support": {
                 "docs": "https://docs.zendframework.com/zend-expressive/",
@@ -855,15 +858,21 @@
                 "slack": "https://zendframework-slack.herokuapp.com",
                 "forum": "https://discourse.zendframework.com/c/questions/expressive"
             },
-            "time": "2017-11-20T08:21:25+00:00"
+            "time": "2017-12-07T22:36:56+00:00"
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "dev-feature/psr-15",
+            "version": "dev-release-3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/zend-expressive-router.git",
-                "reference": "62b11753700ec6c15766412d72dbe11d6fe9c60d"
+                "url": "https://github.com/zendframework/zend-expressive-router.git",
+                "reference": "57ebf529def0743ab9e781040e2a3c5b5aeb7533"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/57ebf529def0743ab9e781040e2a3c5b5aeb7533",
+                "reference": "57ebf529def0743ab9e781040e2a3c5b5aeb7533",
+                "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
@@ -884,8 +893,9 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev",
-                    "dev-develop": "2.3-dev"
+                    "dev-master": "2.2.x-dev",
+                    "dev-develop": "2.3.x-dev",
+                    "dev-release-3.0.0": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -893,48 +903,22 @@
                     "Zend\\Expressive\\Router\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "ZendTest\\Expressive\\Router\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@license-check",
-                    "@cs-check",
-                    "@test"
-                ],
-                "upload-coverage": [
-                    "coveralls -v"
-                ],
-                "cs-check": [
-                    "phpcs --colors"
-                ],
-                "cs-fix": [
-                    "phpcbf --colors"
-                ],
-                "license-check": [
-                    "docheader check src/ test/"
-                ],
-                "test": [
-                    "phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "phpunit --coverage-clover clover.xml"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
             "description": "Router subcomponent for Expressive",
             "keywords": [
+                "ZendFramework",
                 "expressive",
                 "http",
                 "middleware",
                 "psr",
-                "psr-7"
+                "psr-7",
+                "zend-expressive",
+                "zf"
             ],
-            "time": "2017-11-15T22:36:23+00:00"
+            "time": "2017-12-07T17:39:11+00:00"
         },
         {
             "name": "zendframework/zend-expressive-template",
@@ -1032,11 +1016,17 @@
         },
         {
             "name": "zendframework/zend-stratigility",
-            "version": "dev-feature/psr-15",
+            "version": "dev-release-3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/zend-stratigility.git",
-                "reference": "4a1cb4d27f0ee44616c6cb85ec29100cd66d13eb"
+                "url": "https://github.com/zendframework/zend-stratigility.git",
+                "reference": "a27cd099239e97f79d2adae5be7cbd62cda2a592"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/a27cd099239e97f79d2adae5be7cbd62cda2a592",
+                "reference": "a27cd099239e97f79d2adae5be7cbd62cda2a592",
+                "shasum": ""
             },
             "require": {
                 "http-interop/http-server-middleware": "^1.0.1",
@@ -1056,8 +1046,9 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.0-dev",
-                    "dev-develop": "2.2.0-dev"
+                    "dev-master": "2.1.x-dev",
+                    "dev-develop": "2.2.x-dev",
+                    "dev-release-3.0.0": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1065,57 +1056,20 @@
                     "Zend\\Stratigility\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "ZendTest\\Stratigility\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@license-check",
-                    "@cs-check",
-                    "@test"
-                ],
-                "cs-check": [
-                    "phpcs"
-                ],
-                "cs-fix": [
-                    "phpcbf"
-                ],
-                "license-check": [
-                    "docheader check src/ test/"
-                ],
-                "test": [
-                    "phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "phpunit --colors=always --coverage-clover clover.xml"
-                ],
-                "upload-coverage": [
-                    "coveralls -v"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
             "description": "Middleware for PHP",
             "homepage": "https://github.com/zendframework/zend-stratigility",
             "keywords": [
+                "ZendFramework",
                 "http",
                 "middleware",
                 "psr-7",
-                "zendframework",
                 "zf"
             ],
-            "support": {
-                "docs": "https://docs.zendframework.com/zend-stratigility/",
-                "issues": "https://github.com/zendframework/zend-stratigility/issues",
-                "source": "https://github.com/zendframework/zend-stratigility",
-                "rss": "https://github.com/zendframework/zend-stratigility/releases.atom",
-                "slack": "https://zendframework-slack.herokuapp.com",
-                "forum": "https://discourse.zendframework.com/c/questions/expressive"
-            },
-            "time": "2017-11-13T11:14:36+00:00"
+            "time": "2017-12-05T19:16:17+00:00"
         },
         {
             "name": "zfcampus/zf-composer-autoloading",
@@ -1699,22 +1653,22 @@
         },
         {
             "name": "php-mock/php-mock-phpunit",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-mock/php-mock-phpunit.git",
-                "reference": "173781abdc632c59200253e12e2b991ae6a4574f"
+                "reference": "b42fc41ecb7538564067527f6c30b8854f149d32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-mock/php-mock-phpunit/zipball/173781abdc632c59200253e12e2b991ae6a4574f",
-                "reference": "173781abdc632c59200253e12e2b991ae6a4574f",
+                "url": "https://api.github.com/repos/php-mock/php-mock-phpunit/zipball/b42fc41ecb7538564067527f6c30b8854f149d32",
+                "reference": "b42fc41ecb7538564067527f6c30b8854f149d32",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7",
                 "php-mock/php-mock-integration": "^2",
-                "phpunit/phpunit": "^6"
+                "phpunit/phpunit": "^6 <6.5"
             },
             "type": "library",
             "autoload": {
@@ -1746,7 +1700,7 @@
                 "test",
                 "test double"
             ],
-            "time": "2017-02-17T22:44:38+00:00"
+            "time": "2017-12-02T09:49:02+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1804,29 +1758,35 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.1.1",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2"
+                "reference": "66465776cfc249844bde6d117abff1d22e06c2da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2d3d238c433cf69caeb4842e97a3223a116f94b2",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66465776cfc249844bde6d117abff1d22e06c2da",
+                "reference": "66465776cfc249844bde6d117abff1d22e06c2da",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/reflection-common": "^1.0.0",
                 "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -1845,7 +1805,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-30T18:51:59+00:00"
+            "time": "2017-11-27T17:38:31+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -1896,16 +1856,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.2",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
                 "shasum": ""
             },
             "require": {
@@ -1917,7 +1877,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "type": "library",
             "extra": {
@@ -1955,20 +1915,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-09-04T11:05:03+00:00"
+            "time": "2017-11-24T13:59:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.2.3",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d"
+                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
-                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/661f34d0bd3f1a7225ef491a70a020ad23a057a1",
+                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1",
                 "shasum": ""
             },
             "require": {
@@ -1977,14 +1937,13 @@
                 "php": "^7.0",
                 "phpunit/php-file-iterator": "^1.4.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0",
+                "phpunit/php-token-stream": "^2.0.1",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
                 "sebastian/environment": "^3.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.5",
                 "phpunit/phpunit": "^6.0"
             },
             "suggest": {
@@ -1993,7 +1952,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.2.x-dev"
+                    "dev-master": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -2008,7 +1967,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -2019,20 +1978,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-11-03T13:47:33+00:00"
+            "time": "2017-12-06T09:29:45+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -2066,7 +2025,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -2160,16 +2119,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9a02332089ac48e704c70f6cefed30c224e3c0b0",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
@@ -2205,7 +2164,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-08-20T05:47:52+00:00"
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -2989,16 +2948,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v3.3.13",
+            "version": "v3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "138af5ec075d4b1d1bd19de08c38a34bb2d7d880"
+                "reference": "dac8d7db537bac7ad8143eb11360a8c2231f251a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/138af5ec075d4b1d1bd19de08c38a34bb2d7d880",
-                "reference": "138af5ec075d4b1d1bd19de08c38a34bb2d7d880",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/dac8d7db537bac7ad8143eb11360a8c2231f251a",
+                "reference": "dac8d7db537bac7ad8143eb11360a8c2231f251a",
                 "shasum": ""
             },
             "require": {
@@ -3007,7 +2966,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -3034,7 +2993,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-05T15:47:03+00:00"
+            "time": "2017-11-05T16:10:10+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -3158,22 +3117,10 @@
     ],
     "aliases": [
         {
-            "alias": "2.2",
-            "alias_normalized": "2.2.0.0",
+            "alias": "3.0",
+            "alias_normalized": "3.0.0.0",
             "version": "dev-feature/psr-15",
             "package": "zendframework/zend-expressive"
-        },
-        {
-            "alias": "2.2",
-            "alias_normalized": "2.2.0.0",
-            "version": "dev-feature/psr-15",
-            "package": "zendframework/zend-expressive-router"
-        },
-        {
-            "alias": "2.2",
-            "alias_normalized": "2.2.0.0",
-            "version": "dev-feature/psr-15",
-            "package": "zendframework/zend-stratigility"
         }
     ],
     "minimum-stability": "stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "5ab2971d6a3beb8af56265d3db44cfca",
+    "content-hash": "c37c4b3b10259cd0645cb8392e2b262f",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -57,21 +57,21 @@
             "time": "2017-02-09T16:10:21+00:00"
         },
         {
-            "name": "http-interop/http-middleware",
-            "version": "0.4.1",
+            "name": "http-interop/http-server-handler",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/http-interop/http-middleware.git",
-                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9"
+                "url": "https://github.com/http-interop/http-server-handler.git",
+                "reference": "931a6495fb1b6005c9b4abc4dd11fb12a2a8103b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/9a801fe60e70d5d608b61d56b2dcde29516c81b9",
-                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9",
+                "url": "https://api.github.com/repos/http-interop/http-server-handler/zipball/931a6495fb1b6005c9b4abc4dd11fb12a2a8103b",
+                "reference": "931a6495fb1b6005c9b4abc4dd11fb12a2a8103b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0",
+                "php": ">=7.0",
                 "psr/http-message": "^1.0"
             },
             "type": "library",
@@ -82,7 +82,63 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Interop\\Http\\ServerMiddleware\\": "src/"
+                    "Interop\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side request handler",
+            "keywords": [
+                "handler",
+                "http",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response",
+                "server"
+            ],
+            "time": "2017-11-09T18:35:22+00:00"
+        },
+        {
+            "name": "http-interop/http-server-middleware",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/http-interop/http-server-middleware.git",
+                "reference": "e605a7f47a002e857a3b9bb992010e2f859e4560"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/http-interop/http-server-middleware/zipball/e605a7f47a002e857a3b9bb992010e2f859e4560",
+                "reference": "e605a7f47a002e857a3b9bb992010e2f859e4560",
+                "shasum": ""
+            },
+            "require": {
+                "http-interop/http-server-handler": "^1.0",
+                "php": ">=7.0",
+                "psr/http-message": "^1.0"
+            },
+            "replace": {
+                "http-interop/http-middleware": ">=0.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Http\\Server\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -97,16 +153,15 @@
             ],
             "description": "Common interface for HTTP server-side middleware",
             "keywords": [
-                "factory",
                 "http",
                 "middleware",
                 "psr",
-                "psr-17",
+                "psr-15",
                 "psr-7",
                 "request",
                 "response"
             ],
-            "time": "2017-01-14T15:23:42+00:00"
+            "time": "2017-11-09T21:42:30+00:00"
         },
         {
             "name": "psr/container",
@@ -256,25 +311,30 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.2.7",
+            "version": "v3.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c30243cc51f726812be3551316b109a2f5deaf8d"
+                "reference": "63cd7960a0a522c3537f6326706d7f3b8de65805"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c30243cc51f726812be3551316b109a2f5deaf8d",
-                "reference": "c30243cc51f726812be3551316b109a2f5deaf8d",
+                "url": "https://api.github.com/repos/symfony/console/zipball/63cd7960a0a522c3537f6326706d7f3b8de65805",
+                "reference": "63cd7960a0a522c3537f6326706d7f3b8de65805",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "php": "^5.5.9|>=7.0.8",
                 "symfony/debug": "~2.8|~3.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
+            "conflict": {
+                "symfony/dependency-injection": "<3.3"
+            },
             "require-dev": {
                 "psr/log": "~1.0",
+                "symfony/config": "~3.3",
+                "symfony/dependency-injection": "~3.3",
                 "symfony/event-dispatcher": "~2.8|~3.0",
                 "symfony/filesystem": "~2.8|~3.0",
                 "symfony/process": "~2.8|~3.0"
@@ -288,7 +348,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -315,37 +375,36 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-04T14:33:42+00:00"
+            "time": "2017-11-16T15:24:32+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.2.7",
+            "version": "v3.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "56f613406446a4a0a031475cfd0a01751de22659"
+                "reference": "74557880e2846b5c84029faa96b834da37e29810"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/56f613406446a4a0a031475cfd0a01751de22659",
-                "reference": "56f613406446a4a0a031475cfd0a01751de22659",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/74557880e2846b5c84029faa96b834da37e29810",
+                "reference": "74557880e2846b5c84029faa96b834da37e29810",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "php": "^5.5.9|>=7.0.8",
                 "psr/log": "~1.0"
             },
             "conflict": {
                 "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
             },
             "require-dev": {
-                "symfony/class-loader": "~2.8|~3.0",
                 "symfony/http-kernel": "~2.8|~3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -372,20 +431,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-28T21:38:24+00:00"
+            "time": "2017-11-10T16:38:39+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.3.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4"
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/e79d363049d1c2128f133a2667e4f4190904f7f4",
-                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
                 "shasum": ""
             },
             "require": {
@@ -397,7 +456,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -431,31 +490,31 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "zendframework/zend-code",
-            "version": "3.1.0",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-code.git",
-                "reference": "2899c17f83a7207f2d7f53ec2f421204d3beea27"
+                "reference": "6b1059db5b368db769e4392c6cb6cc139e56640d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/2899c17f83a7207f2d7f53ec2f421204d3beea27",
-                "reference": "2899c17f83a7207f2d7f53ec2f421204d3beea27",
+                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/6b1059db5b368db769e4392c6cb6cc139e56640d",
+                "reference": "6b1059db5b368db769e4392c6cb6cc139e56640d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || 7.0.0 - 7.0.4 || ^7.0.6",
+                "php": "^7.1",
                 "zendframework/zend-eventmanager": "^2.6 || ^3.0"
             },
             "require-dev": {
                 "doctrine/annotations": "~1.0",
                 "ext-phar": "*",
-                "phpunit/phpunit": "^4.8.21",
-                "squizlabs/php_codesniffer": "^2.5",
+                "phpunit/phpunit": "^6.2.3",
+                "zendframework/zend-coding-standard": "^1.0.0",
                 "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "suggest": {
@@ -465,8 +524,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev",
-                    "dev-develop": "3.2-dev"
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
                 }
             },
             "autoload": {
@@ -484,20 +543,20 @@
                 "code",
                 "zf2"
             ],
-            "time": "2016-10-24T13:23:32+00:00"
+            "time": "2017-10-20T15:21:32+00:00"
         },
         {
             "name": "zendframework/zend-component-installer",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-component-installer.git",
-                "reference": "0ca44807dbcf356b75a869c61b533f917ccbc5ae"
+                "reference": "ca728bb1fcff9b0e945ac472bf8d6031e25edf28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-component-installer/zipball/0ca44807dbcf356b75a869c61b533f917ccbc5ae",
-                "reference": "0ca44807dbcf356b75a869c61b533f917ccbc5ae",
+                "url": "https://api.github.com/repos/zendframework/zend-component-installer/zipball/ca728bb1fcff9b0e945ac472bf8d6031e25edf28",
+                "reference": "ca728bb1fcff9b0e945ac472bf8d6031e25edf28",
                 "shasum": ""
             },
             "require": {
@@ -505,16 +564,17 @@
                 "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "composer/composer": "^1.3.2",
-                "malukenho/docheader": "^0.1.5",
-                "mikey179/vfsstream": "^1.6",
-                "phpunit/phpunit": "^6.0.7 || ^5.7.14",
+                "composer/composer": "^1.5.2",
+                "malukenho/docheader": "^0.1.6",
+                "mikey179/vfsstream": "^1.6.5",
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "composer-plugin",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.1-dev",
+                    "dev-develop": "1.2-dev"
                 },
                 "class": "Zend\\ComponentInstaller\\ComponentInstaller"
             },
@@ -528,25 +588,32 @@
                 "BSD-3-Clause"
             ],
             "description": "Composer plugin for automating component registration in zend-mvc and Expressive applications",
-            "time": "2017-04-25T16:43:54+00:00"
+            "keywords": [
+                "ZendFramework",
+                "component installer",
+                "composer",
+                "plugin",
+                "zf"
+            ],
+            "time": "2017-11-06T22:50:20+00:00"
         },
         {
             "name": "zendframework/zend-diactoros",
-            "version": "1.4.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "b03f285a333f51e58c95cce54109a4a9ed691436"
+                "reference": "c8664b92a6d5bc229e48b0923486c097e45a7877"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/b03f285a333f51e58c95cce54109a4a9ed691436",
-                "reference": "b03f285a333f51e58c95cce54109a4a9ed691436",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/c8664b92a6d5bc229e48b0923486c097e45a7877",
+                "reference": "c8664b92a6d5bc229e48b0923486c097e45a7877",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.4 || ^7.0",
-                "psr/http-message": "~1.0"
+                "php": "^5.6 || ^7.0",
+                "psr/http-message": "^1.0"
             },
             "provide": {
                 "psr/http-message-implementation": "1.0"
@@ -554,14 +621,14 @@
             "require-dev": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
-                "phpunit/phpunit": "^4.6 || ^5.5",
-                "zendframework/zend-coding-standard": "~1.0.0"
+                "phpunit/phpunit": "^5.7.16 || ^6.0.8",
+                "zendframework/zend-coding-standard": "~1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev",
-                    "dev-develop": "1.5-dev"
+                    "dev-master": "1.6-dev",
+                    "dev-develop": "1.7-dev"
                 }
             },
             "autoload": {
@@ -580,7 +647,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-04-06T16:18:34+00:00"
+            "time": "2017-10-12T15:24:51+00:00"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -628,16 +695,16 @@
         },
         {
             "name": "zendframework/zend-eventmanager",
-            "version": "3.1.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-eventmanager.git",
-                "reference": "c3bce7b7d47c54040b9ae51bc55491c72513b75d"
+                "reference": "9d72db10ceb6e42fb92350c0cb54460da61bd79c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/c3bce7b7d47c54040b9ae51bc55491c72513b75d",
-                "reference": "c3bce7b7d47c54040b9ae51bc55491c72513b75d",
+                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/9d72db10ceb6e42fb92350c0cb54460da61bd79c",
+                "reference": "9d72db10ceb6e42fb92350c0cb54460da61bd79c",
                 "shasum": ""
             },
             "require": {
@@ -646,7 +713,7 @@
             "require-dev": {
                 "athletic/athletic": "^0.1",
                 "container-interop/container-interop": "^1.1.0",
-                "phpunit/phpunit": "^5.6",
+                "phpunit/phpunit": "^6.0.7 || ^5.7.14",
                 "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-stdlib": "^2.7.3 || ^3.0"
             },
@@ -657,8 +724,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev",
-                    "dev-develop": "3.2-dev"
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
                 }
             },
             "autoload": {
@@ -678,45 +745,40 @@
                 "events",
                 "zf2"
             ],
-            "time": "2016-12-19T21:47:12+00:00"
+            "time": "2017-07-11T19:17:22+00:00"
         },
         {
             "name": "zendframework/zend-expressive",
-            "version": "2.0.3",
+            "version": "dev-feature/psr-15",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-expressive.git",
-                "reference": "293145df73f288b16107d1388995282c4e8599fd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive/zipball/293145df73f288b16107d1388995282c4e8599fd",
-                "reference": "293145df73f288b16107d1388995282c4e8599fd",
-                "shasum": ""
+                "url": "https://github.com/webimpress/zend-expressive.git",
+                "reference": "1bf07dd1afe04e23265bd735e32ddc478e88933a"
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
-                "php": "^5.6 || ^7.0",
+                "http-interop/http-server-middleware": "^1.0.1",
+                "php": "^7.1",
                 "psr/container": "^1.0",
                 "psr/http-message": "^1.0.1",
                 "zendframework/zend-diactoros": "^1.3.10",
-                "zendframework/zend-expressive-router": "^2.1",
+                "zendframework/zend-expressive-router": "dev-feature/psr-15 as 2.2",
                 "zendframework/zend-expressive-template": "^1.0.4",
-                "zendframework/zend-stratigility": "^2.0.1"
+                "zendframework/zend-stratigility": "dev-feature/psr-15 as 2.2"
             },
             "conflict": {
                 "container-interop/container-interop": "<1.2.0"
             },
             "require-dev": {
-                "filp/whoops": "^2.1.6 || ^1.1.10",
-                "malukenho/docheader": "^0.1.5",
-                "mockery/mockery": "^0.9.5",
-                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "filp/whoops": "^1.1.10 || ^2.1.13",
+                "malukenho/docheader": "^0.1.6",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4.4",
                 "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-expressive-aurarouter": "^2.0",
                 "zendframework/zend-expressive-fastroute": "^2.0",
                 "zendframework/zend-expressive-zendrouter": "^2.0.1",
-                "zendframework/zend-servicemanager": "^3.3 || ^2.7.8"
+                "zendframework/zend-servicemanager": "^2.7.8 || ^3.3"
             },
             "suggest": {
                 "aura/di": "^3.2 to make use of Aura.Di dependency injection container",
@@ -741,42 +803,77 @@
                     "Zend\\Expressive\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Expressive\\": "test/"
+                },
+                "files": [
+                    "test/class_exists.php"
+                ]
+            },
+            "scripts": {
+                "check": [
+                    "@license-check",
+                    "@cs-check",
+                    "@test"
+                ],
+                "upload-coverage": [
+                    "coveralls -v"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --coverage-clover clover.xml"
+                ],
+                "license-check": [
+                    "vendor/bin/docheader check src/ test/"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
             "description": "PSR-7 Middleware Microframework based on Stratigility",
+            "homepage": "https://docs.zendframework.com/zend-expressive/",
             "keywords": [
                 "http",
                 "middleware",
                 "psr",
+                "psr-11",
                 "psr-7"
             ],
-            "time": "2017-03-28T15:56:53+00:00"
+            "support": {
+                "docs": "https://docs.zendframework.com/zend-expressive/",
+                "issues": "https://github.com/zendframework/zend-expressive/issues",
+                "source": "https://github.com/zendframework/zend-expressive",
+                "slack": "https://zendframework-slack.herokuapp.com",
+                "forum": "https://discourse.zendframework.com/c/questions/expressive"
+            },
+            "time": "2017-11-20T08:21:25+00:00"
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "2.1.0",
+            "version": "dev-feature/psr-15",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "88d711aee740ac8fbd684472469e16b85435cc79"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/88d711aee740ac8fbd684472469e16b85435cc79",
-                "reference": "88d711aee740ac8fbd684472469e16b85435cc79",
-                "shasum": ""
+                "url": "https://github.com/webimpress/zend-expressive-router.git",
+                "reference": "62b11753700ec6c15766412d72dbe11d6fe9c60d"
             },
             "require": {
-                "fig/http-message-util": "^1.1",
-                "http-interop/http-middleware": "^0.4.1",
-                "php": "^5.6 || ^7.0",
-                "psr/http-message": "^1.0"
+                "fig/http-message-util": "^1.1.2",
+                "http-interop/http-server-middleware": "^1.0.1",
+                "php": "^7.1",
+                "psr/http-message": "^1.0.1"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
-                "phpunit/phpunit": "^4.7 || ^5.6",
+                "phpunit/phpunit": "^6.4.4",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
@@ -787,8 +884,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev",
-                    "dev-develop": "2.2-dev"
+                    "dev-master": "2.2-dev",
+                    "dev-develop": "2.3-dev"
                 }
             },
             "autoload": {
@@ -796,7 +893,36 @@
                     "Zend\\Expressive\\Router\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Expressive\\Router\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@license-check",
+                    "@cs-check",
+                    "@test"
+                ],
+                "upload-coverage": [
+                    "coveralls -v"
+                ],
+                "cs-check": [
+                    "phpcs --colors"
+                ],
+                "cs-fix": [
+                    "phpcbf --colors"
+                ],
+                "license-check": [
+                    "docheader check src/ test/"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --coverage-clover clover.xml"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
@@ -808,7 +934,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-01-24T22:28:12+00:00"
+            "time": "2017-11-15T22:36:23+00:00"
         },
         {
             "name": "zendframework/zend-expressive-template",
@@ -906,27 +1032,21 @@
         },
         {
             "name": "zendframework/zend-stratigility",
-            "version": "2.0.1",
+            "version": "dev-feature/psr-15",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-stratigility.git",
-                "reference": "229e7d94010d09d9e68096ff6f1d35f354d8dac9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/229e7d94010d09d9e68096ff6f1d35f354d8dac9",
-                "reference": "229e7d94010d09d9e68096ff6f1d35f354d8dac9",
-                "shasum": ""
+                "url": "https://github.com/webimpress/zend-stratigility.git",
+                "reference": "4a1cb4d27f0ee44616c6cb85ec29100cd66d13eb"
             },
             "require": {
-                "http-interop/http-middleware": "^0.4.1",
-                "php": "^5.6 || ^7.0",
+                "http-interop/http-server-middleware": "^1.0.1",
+                "php": "^7.1",
                 "psr/http-message": "^1.0",
                 "zendframework/zend-escaper": "^2.3"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
-                "phpunit/phpunit": "^5.7",
+                "phpunit/phpunit": "^5.7.22 || ^6.4.1",
                 "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-diactoros": "^1.0"
             },
@@ -936,8 +1056,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.0-dev",
-                    "dev-develop": "2.1.0-dev"
+                    "dev-master": "2.1.0-dev",
+                    "dev-develop": "2.2.0-dev"
                 }
             },
             "autoload": {
@@ -945,7 +1065,36 @@
                     "Zend\\Stratigility\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Stratigility\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@license-check",
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "license-check": [
+                    "docheader check src/ test/"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ],
+                "upload-coverage": [
+                    "coveralls -v"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
@@ -954,9 +1103,19 @@
             "keywords": [
                 "http",
                 "middleware",
-                "psr-7"
+                "psr-7",
+                "zendframework",
+                "zf"
             ],
-            "time": "2017-01-25T19:16:16+00:00"
+            "support": {
+                "docs": "https://docs.zendframework.com/zend-stratigility/",
+                "issues": "https://github.com/zendframework/zend-stratigility/issues",
+                "source": "https://github.com/zendframework/zend-stratigility",
+                "rss": "https://github.com/zendframework/zend-stratigility/releases.atom",
+                "slack": "https://zendframework-slack.herokuapp.com",
+                "forum": "https://discourse.zendframework.com/c/questions/expressive"
+            },
+            "time": "2017-11-13T11:14:36+00:00"
         },
         {
             "name": "zfcampus/zf-composer-autoloading",
@@ -1015,32 +1174,32 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -1065,24 +1224,24 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2017-07-22T11:58:36+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
-            "version": "v1.2.2",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "b37020aa976fa52d3de9aa904aa2522dc518f79c"
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/b37020aa976fa52d3de9aa904aa2522dc518f79c",
-                "reference": "b37020aa976fa52d3de9aa904aa2522dc518f79c",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^5.3|^7.0"
             },
             "replace": {
                 "cordoval/hamcrest-php": "*",
@@ -1091,15 +1250,18 @@
             },
             "require-dev": {
                 "phpunit/php-file-iterator": "1.3.3",
-                "satooshi/php-coveralls": "dev-master"
+                "phpunit/phpunit": "~4.0",
+                "satooshi/php-coveralls": "^1.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "hamcrest"
-                ],
-                "files": [
-                    "hamcrest/Hamcrest.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1110,20 +1272,20 @@
             "keywords": [
                 "test"
             ],
-            "time": "2015-05-11T14:41:42+00:00"
+            "time": "2016-01-20T08:20:44+00:00"
         },
         {
             "name": "malukenho/docheader",
-            "version": "0.1.5",
+            "version": "0.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/malukenho/docheader.git",
-                "reference": "f35ada934d1de3f5ba09970a6541009a41347658"
+                "reference": "b3857387fe5e6b0928b67875ea09ebb5745d5b8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/malukenho/docheader/zipball/f35ada934d1de3f5ba09970a6541009a41347658",
-                "reference": "f35ada934d1de3f5ba09970a6541009a41347658",
+                "url": "https://api.github.com/repos/malukenho/docheader/zipball/b3857387fe5e6b0928b67875ea09ebb5745d5b8b",
+                "reference": "b3857387fe5e6b0928b67875ea09ebb5745d5b8b",
                 "shasum": ""
             },
             "require": {
@@ -1132,7 +1294,8 @@
                 "symfony/finder": "~2.0|^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.7"
+                "phpunit/phpunit": "^4.7",
+                "squizlabs/php_codesniffer": "^2.8"
             },
             "bin": [
                 "bin/docheader"
@@ -1160,20 +1323,20 @@
                 "code standard",
                 "license"
             ],
-            "time": "2016-11-17T16:46:05+00:00"
+            "time": "2017-05-03T05:22:55+00:00"
         },
         {
             "name": "mikey179/vfsStream",
-            "version": "v1.6.4",
+            "version": "v1.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mikey179/vfsStream.git",
-                "reference": "0247f57b2245e8ad2e689d7cee754b45fbabd592"
+                "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/0247f57b2245e8ad2e689d7cee754b45fbabd592",
-                "reference": "0247f57b2245e8ad2e689d7cee754b45fbabd592",
+                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
+                "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
                 "shasum": ""
             },
             "require": {
@@ -1206,34 +1369,34 @@
             ],
             "description": "Virtual file system to mock the real file system in unit tests.",
             "homepage": "http://vfs.bovigo.org/",
-            "time": "2016-07-18T14:02:57+00:00"
+            "time": "2017-08-01T08:02:14+00:00"
         },
         {
             "name": "mockery/mockery",
-            "version": "0.9.9",
+            "version": "1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "6fdb61243844dc924071d3404bb23994ea0b6856"
+                "reference": "1bac8c362b12f522fdd1f1fa3556284c91affa38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/6fdb61243844dc924071d3404bb23994ea0b6856",
-                "reference": "6fdb61243844dc924071d3404bb23994ea0b6856",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1bac8c362b12f522fdd1f1fa3556284c91affa38",
+                "reference": "1bac8c362b12f522fdd1f1fa3556284c91affa38",
                 "shasum": ""
             },
             "require": {
-                "hamcrest/hamcrest-php": "~1.1",
+                "hamcrest/hamcrest-php": "~2.0",
                 "lib-pcre": ">=7.0",
-                "php": ">=5.3.2"
+                "php": ">=5.6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "~5.7|~6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.9.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -1258,7 +1421,7 @@
                 }
             ],
             "description": "Mockery is a simple yet flexible PHP mock object framework for use in unit testing with PHPUnit, PHPSpec or any other testing framework. Its core goal is to offer a test double framework with a succinct API capable of clearly defining all possible object operations and interactions using a human readable Domain Specific Language (DSL). Designed as a drop in alternative to PHPUnit's phpunit-mock-objects library, Mockery is easy to integrate with PHPUnit and can operate alongside phpunit-mock-objects without the World ending.",
-            "homepage": "http://github.com/padraic/mockery",
+            "homepage": "http://github.com/mockery/mockery",
             "keywords": [
                 "BDD",
                 "TDD",
@@ -1271,41 +1434,44 @@
                 "test double",
                 "testing"
             ],
-            "time": "2017-02-28T12:52:32+00:00"
+            "time": "2017-10-06T16:20:43+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.6.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102"
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8e6e04167378abf1ddb4d3522d8755c5fd90d102",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "DeepCopy\\": "src/DeepCopy/"
-                }
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
             "keywords": [
                 "clone",
                 "copy",
@@ -1313,7 +1479,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-04-12T18:52:22+00:00"
+            "time": "2017-10-19T19:58:43+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1584,16 +1750,16 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
@@ -1634,26 +1800,26 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.1",
+            "version": "4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2d3d238c433cf69caeb4842e97a3223a116f94b2",
+                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": "^7.0",
                 "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.2.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
@@ -1679,24 +1845,24 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30T07:12:33+00:00"
+            "time": "2017-08-30T18:51:59+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2.1",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": "^5.5 || ^7.0",
                 "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
@@ -1726,26 +1892,26 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25T06:54:22+00:00"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.0",
+            "version": "v1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
                 "sebastian/comparator": "^1.1|^2.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
@@ -1756,7 +1922,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -1789,32 +1955,32 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2017-09-04T11:05:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.2.1",
+            "version": "5.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "dc421f9ca5082a0c0cb04afb171c765f79add85b"
+                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/dc421f9ca5082a0c0cb04afb171c765f79add85b",
-                "reference": "dc421f9ca5082a0c0cb04afb171c765f79add85b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
+                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
                 "php": "^7.0",
-                "phpunit/php-file-iterator": "^1.3",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-token-stream": "^1.4.11 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
                 "sebastian/environment": "^3.0",
-                "sebastian/version": "^2.0",
+                "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
@@ -1822,7 +1988,7 @@
                 "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.3"
+                "ext-xdebug": "^2.5.5"
             },
             "type": "library",
             "extra": {
@@ -1853,7 +2019,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-21T08:03:57+00:00"
+            "time": "2017-11-03T13:47:33+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1994,29 +2160,29 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.11",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
+                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9a02332089ac48e704c70f6cefed30c224e3c0b0",
+                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2039,20 +2205,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27T10:12:30+00:00"
+            "time": "2017-08-20T05:47:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.1.2",
+            "version": "6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fbf2e46d5c563ee78c9b559bcbeb1c97cad6af0f"
+                "reference": "562f7dc75d46510a4ed5d16189ae57fbe45a9932"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fbf2e46d5c563ee78c9b559bcbeb1c97cad6af0f",
-                "reference": "fbf2e46d5c563ee78c9b559bcbeb1c97cad6af0f",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/562f7dc75d46510a4ed5d16189ae57fbe45a9932",
+                "reference": "562f7dc75d46510a4ed5d16189ae57fbe45a9932",
                 "shasum": ""
             },
             "require": {
@@ -2061,24 +2227,24 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.3",
+                "myclabs/deep-copy": "^1.6.1",
                 "phar-io/manifest": "^1.0.1",
                 "phar-io/version": "^1.0",
                 "php": "^7.0",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.2",
-                "phpunit/php-file-iterator": "^1.4",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^4.0",
-                "sebastian/comparator": "^2.0",
-                "sebastian/diff": "^1.2",
-                "sebastian/environment": "^3.0.1",
+                "phpunit/php-code-coverage": "^5.2.2",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^1.0.9",
+                "phpunit/phpunit-mock-objects": "^4.0.3",
+                "sebastian/comparator": "^2.0.2",
+                "sebastian/diff": "^2.0",
+                "sebastian/environment": "^3.1",
                 "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^1.1 || ^2.0",
-                "sebastian/object-enumerator": "^3.0.2",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
                 "sebastian/resource-operations": "^1.0",
-                "sebastian/version": "^2.0"
+                "sebastian/version": "^2.0.1"
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "3.0.2",
@@ -2097,7 +2263,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1.x-dev"
+                    "dev-master": "6.4.x-dev"
                 }
             },
             "autoload": {
@@ -2123,26 +2289,26 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-25T21:30:13+00:00"
+            "time": "2017-11-08T11:26:09+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "4.0.1",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "eabce450df194817a7d7e27e19013569a903a2bf"
+                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/eabce450df194817a7d7e27e19013569a903a2bf",
-                "reference": "eabce450df194817a7d7e27e19013569a903a2bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/2f789b59ab89669015ad984afa350c4ec577ade0",
+                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
+                "doctrine/instantiator": "^1.0.5",
                 "php": "^7.0",
-                "phpunit/php-text-template": "^1.2",
+                "phpunit/php-text-template": "^1.2.1",
                 "sebastian/exporter": "^3.0"
             },
             "conflict": {
@@ -2182,7 +2348,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-03-03T06:30:20+00:00"
+            "time": "2017-08-03T14:08:16+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2231,30 +2397,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "20f84f468cb67efee293246e6a09619b891f55f0"
+                "reference": "1174d9018191e93cb9d719edec01257fc05f8158"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/20f84f468cb67efee293246e6a09619b891f55f0",
-                "reference": "20f84f468cb67efee293246e6a09619b891f55f0",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1174d9018191e93cb9d719edec01257fc05f8158",
+                "reference": "1174d9018191e93cb9d719edec01257fc05f8158",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "sebastian/diff": "^1.2",
-                "sebastian/exporter": "^3.0"
+                "sebastian/diff": "^2.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -2285,38 +2451,38 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-03-03T06:26:08+00:00"
+            "time": "2017-11-03T07:16:52+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2343,20 +2509,20 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08T07:14:41+00:00"
+            "time": "2017-08-03T08:09:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.0.2",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "11e7710b7724d42c62249b0e9d3030240398949d"
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/11e7710b7724d42c62249b0e9d3030240398949d",
-                "reference": "11e7710b7724d42c62249b0e9d3030240398949d",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "shasum": ""
             },
             "require": {
@@ -2368,7 +2534,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -2393,7 +2559,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-04-21T14:40:32+00:00"
+            "time": "2017-07-01T08:51:00+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -2515,21 +2681,21 @@
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "31dd3379d16446c5d86dec32ab1ad1f378581ad8"
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/31dd3379d16446c5d86dec32ab1ad1f378581ad8",
-                "reference": "31dd3379d16446c5d86dec32ab1ad1f378581ad8",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "sebastian/object-reflector": "^1.0",
+                "sebastian/object-reflector": "^1.1.1",
                 "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
@@ -2558,7 +2724,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-03-12T15:17:29+00:00"
+            "time": "2017-08-03T12:35:26+00:00"
         },
         {
             "name": "sebastian/object-reflector",
@@ -2745,16 +2911,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.8.1",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d"
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
                 "shasum": ""
             },
             "require": {
@@ -2819,29 +2985,29 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-03-01T22:17:45+00:00"
+            "time": "2017-05-22T02:43:20+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.2.7",
+            "version": "v3.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "b20900ce5ea164cd9314af52725b0bb5a758217a"
+                "reference": "138af5ec075d4b1d1bd19de08c38a34bb2d7d880"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/b20900ce5ea164cd9314af52725b0bb5a758217a",
-                "reference": "b20900ce5ea164cd9314af52725b0bb5a758217a",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/138af5ec075d4b1d1bd19de08c38a34bb2d7d880",
+                "reference": "138af5ec075d4b1d1bd19de08c38a34bb2d7d880",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -2868,7 +3034,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-20T09:32:19+00:00"
+            "time": "2017-11-05T15:47:03+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2990,13 +3156,36 @@
             "time": "2016-11-09T21:30:43+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "2.2",
+            "alias_normalized": "2.2.0.0",
+            "version": "dev-feature/psr-15",
+            "package": "zendframework/zend-expressive"
+        },
+        {
+            "alias": "2.2",
+            "alias_normalized": "2.2.0.0",
+            "version": "dev-feature/psr-15",
+            "package": "zendframework/zend-expressive-router"
+        },
+        {
+            "alias": "2.2",
+            "alias_normalized": "2.2.0.0",
+            "version": "dev-feature/psr-15",
+            "package": "zendframework/zend-stratigility"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zendframework/zend-expressive": 20,
+        "zendframework/zend-expressive-router": 20,
+        "zendframework/zend-stratigility": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6 || ^7.0"
+        "php": "^7.1"
     },
     "platform-dev": []
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,4 +5,5 @@
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
+    <exclude-pattern>*/TestAsset/*</exclude-pattern>
 </ruleset>

--- a/src/CreateMiddleware/CreateMiddleware.php
+++ b/src/CreateMiddleware/CreateMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/CreateMiddleware/CreateMiddleware.php
+++ b/src/CreateMiddleware/CreateMiddleware.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\CreateMiddleware;
 
 /**

--- a/src/CreateMiddleware/CreateMiddleware.php
+++ b/src/CreateMiddleware/CreateMiddleware.php
@@ -22,8 +22,9 @@ class CreateMiddleware
 
 namespace %namespace%;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class %class% implements MiddlewareInterface
@@ -31,7 +32,7 @@ class %class% implements MiddlewareInterface
     /**
      * {@inheritDoc}
      */
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         // $response = $delegate->process($request);
     }

--- a/src/CreateMiddleware/CreateMiddlewareCommand.php
+++ b/src/CreateMiddleware/CreateMiddlewareCommand.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/CreateMiddleware/CreateMiddlewareCommand.php
+++ b/src/CreateMiddleware/CreateMiddlewareCommand.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\CreateMiddleware;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/CreateMiddleware/CreateMiddlewareException.php
+++ b/src/CreateMiddleware/CreateMiddlewareException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\CreateMiddleware;
 
 use RuntimeException;

--- a/src/CreateMiddleware/CreateMiddlewareException.php
+++ b/src/CreateMiddleware/CreateMiddlewareException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/GenerateProgrammaticPipelineFromConfig/Constants.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Constants.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/GenerateProgrammaticPipelineFromConfig/Constants.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Constants.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\GenerateProgrammaticPipelineFromConfig;
 
 interface Constants

--- a/src/GenerateProgrammaticPipelineFromConfig/Generator.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Generator.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/GenerateProgrammaticPipelineFromConfig/Generator.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Generator.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\GenerateProgrammaticPipelineFromConfig;
 
 use ArrayObject;

--- a/src/GenerateProgrammaticPipelineFromConfig/GeneratorException.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/GeneratorException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/GenerateProgrammaticPipelineFromConfig/GeneratorException.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/GeneratorException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\GenerateProgrammaticPipelineFromConfig;
 
 use RuntimeException;

--- a/src/GenerateProgrammaticPipelineFromConfig/PipelineFromConfigCommand.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/PipelineFromConfigCommand.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/GenerateProgrammaticPipelineFromConfig/PipelineFromConfigCommand.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/PipelineFromConfigCommand.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\GenerateProgrammaticPipelineFromConfig;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/MigrateInteropMiddleware/ArgvException.php
+++ b/src/MigrateInteropMiddleware/ArgvException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\MigrateInteropMiddleware;
 
 use RuntimeException;

--- a/src/MigrateInteropMiddleware/ArgvException.php
+++ b/src/MigrateInteropMiddleware/ArgvException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/MigrateInteropMiddleware/ArgvException.php
+++ b/src/MigrateInteropMiddleware/ArgvException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Tooling\MigrateInteropMiddleware;
+
+use RuntimeException;
+
+class ArgvException extends RuntimeException
+{
+}

--- a/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
+++ b/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\MigrateInteropMiddleware;
 
 use RecursiveDirectoryIterator;

--- a/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
+++ b/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
@@ -98,12 +98,14 @@ class ConvertInteropMiddleware
 
         if ($middleware
             && preg_match('#class\s+[^{]+?implements\s*([^{]+?,\s*)*' . $middleware . '(\s|,|{)#i', $contents)
-            && preg_match('#public\s+function\s+process\([^\)]+?\)\s*{#', $contents, $matches)
+            && preg_match('#public\s+function\s+process\(\s*.+?,\s*.+?\s+(\$.+?)\s*\)\s*{#', $contents, $matches)
         ) {
             $ri = $this->getResponseInterface($contents);
             $replacement = preg_replace('#\)#', ') : ' . $ri, $matches[0]);
 
             $contents = str_replace($matches[0], $replacement, $contents);
+            $preg = '/' . preg_quote($matches[1], '\\') . '\s*->\s*process\(/';
+            $contents = preg_replace($preg, $matches[1] . '->handle(', $contents);
         }
 
         if ($original === $contents) {

--- a/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
+++ b/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
@@ -43,7 +43,7 @@ class ConvertInteropMiddleware
             && $file->isWritable();
     }
 
-    private function processFile($filename) : void
+    private function processFile(string $filename) : void
     {
         $original = file_get_contents($filename);
         $contents = $original;

--- a/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
+++ b/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
+++ b/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
@@ -82,7 +82,7 @@ class ConvertInteropMiddleware
             );
         }
 
-        // if delegate and class implements delegate interface
+        // if delegate, class implements delegate interface and has process method
         if ($delegate
             && preg_match('#class\s+[^{]+?implements\s*([^{]+?,\s*)*' . $delegate . '(\s|,|{)#i', $contents)
             && preg_match('#public\s+function\s+process\s*\([^\)]+?\)\s*(:?)#', $contents, $matches)
@@ -96,6 +96,7 @@ class ConvertInteropMiddleware
             $contents = str_replace($matches[0], $replacement, $contents);
         }
 
+        // is middleware, class implements middleware interface and has process method
         if ($middleware
             && preg_match('#class\s+[^{]+?implements\s*([^{]+?,\s*)*' . $middleware . '(\s|,|{)#i', $contents)
             && preg_match('#public\s+function\s+process\(\s*.+?,\s*.+?\s+(\$.+?)\s*\)\s*{#', $contents, $matches)

--- a/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
+++ b/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Tooling\MigrateInteropMiddleware;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ConvertInteropMiddleware
+{
+    private $output;
+
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    public function process(string $directory)
+    {
+        $rdi = new RecursiveDirectoryIterator($directory);
+        $rii = new RecursiveIteratorIterator($rdi);
+
+        foreach ($rii as $file) {
+            if (! $this->isPhpFile($file)) {
+                continue;
+            }
+
+            $this->processFile((string) $file);
+        }
+    }
+
+    private function isPhpFile(SplFileInfo $file) : bool
+    {
+        return $file->isFile()
+            && $file->getExtension() === 'php'
+            && $file->isReadable()
+            && $file->isWritable();
+    }
+
+    private function processFile($filename) : void
+    {
+        $original = file_get_contents($filename);
+        $contents = $original;
+
+        $delegate = null;
+        if (preg_match(
+            '#use\s+Interop\\\\Http\\\\ServerMiddleware\\\\DelegateInterface(\s*)(;|as\s*([^; ]+)\s*;)#',
+            $contents,
+            $matches
+        )) {
+            $delegate = $matches[2] === ';' ? 'DelegateInterface' : $matches[3];
+
+            $replacement = $matches[2] === ';'
+                ? ' as DelegateInterface;'
+                : $matches[1] . $matches[2];
+
+            $contents = str_replace(
+                $matches[0],
+                'use Interop\\Http\\Server\\RequestHandlerInterface' . $replacement,
+                $contents
+            );
+        }
+
+        $middleware = null;
+        if (preg_match(
+            '#use\s+Interop\\\\Http\\\\ServerMiddleware\\\\MiddlewareInterface(\s*)(;|as\s*([^;\s]+)\s*;)#',
+            $contents,
+            $matches
+        )) {
+            $middleware = $matches[2] === ';' ? 'MiddlewareInterface' : $matches[3];
+
+            $contents = str_replace(
+                $matches[0],
+                'use Interop\\Http\\Server\\MiddlewareInterface' . $matches[1] . $matches[2],
+                $contents
+            );
+        }
+
+        // if delegate and class implements delegate interface
+        if ($delegate
+            && preg_match('#class\s+[^{]+?implements\s*([^{]+?,\s*)*' . $delegate . '(\s|,|{)#i', $contents)
+            && preg_match('#public\s+function\s+delegate\s*\([^\)]+?\)\s*(:?)#', $contents, $matches)
+        ) {
+            $replacement = str_replace('delegate', 'handle', $matches[0]);
+            if ($matches[1] !== ':') {
+                $ri = $this->getResponseInterface($contents);
+                $replacement = preg_replace('#\)#', ') : ' . $ri, $replacement);
+            }
+
+            $contents = str_replace($matches[0], $replacement, $contents);
+        }
+
+        if ($middleware
+            && preg_match('#class\s+[^{]+?implements\s*([^{]+?,\s*)*' . $middleware . '(\s|,|{)#i', $contents)
+            && preg_match('#public\s+function\s+process\([^\)]+?\)\s*{#', $contents, $matches)
+        ) {
+            $ri = $this->getResponseInterface($contents);
+            $replacement = preg_replace('#\)#', ') : ' . $ri, $matches[0]);
+
+            $contents = str_replace($matches[0], $replacement, $contents);
+        }
+
+        if ($original === $contents) {
+            return;
+        }
+
+        $this->output->writeln(sprintf('<info>- Updating %s</info>', $filename));
+
+        file_put_contents($filename, $contents);
+    }
+
+    private function getResponseInterface(string $content)
+    {
+        $responseInterface = null;
+        if (preg_match(
+            '#use\s*Psr\\\\Http\\\\Message\\\\ResponseInterface\s*(;|as\s*([^;\s]+)\s*;)#',
+            $content,
+            $matches
+        )) {
+            if ($matches[1] === ';') {
+                return 'ResponseInterface';
+            }
+
+            return $matches[2];
+        }
+
+        return '\Psr\Http\Message\ResponseInterface';
+    }
+}

--- a/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
+++ b/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
@@ -85,9 +85,9 @@ class ConvertInteropMiddleware
         // if delegate and class implements delegate interface
         if ($delegate
             && preg_match('#class\s+[^{]+?implements\s*([^{]+?,\s*)*' . $delegate . '(\s|,|{)#i', $contents)
-            && preg_match('#public\s+function\s+delegate\s*\([^\)]+?\)\s*(:?)#', $contents, $matches)
+            && preg_match('#public\s+function\s+process\s*\([^\)]+?\)\s*(:?)#', $contents, $matches)
         ) {
-            $replacement = str_replace('delegate', 'handle', $matches[0]);
+            $replacement = str_replace('process', 'handle', $matches[0]);
             if ($matches[1] !== ':') {
                 $ri = $this->getResponseInterface($contents);
                 $replacement = preg_replace('#\)#', ') : ' . $ri, $replacement);

--- a/src/MigrateInteropMiddleware/MigrateInteropMiddlewareCommand.php
+++ b/src/MigrateInteropMiddleware/MigrateInteropMiddlewareCommand.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\MigrateInteropMiddleware;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/MigrateInteropMiddleware/MigrateInteropMiddlewareCommand.php
+++ b/src/MigrateInteropMiddleware/MigrateInteropMiddlewareCommand.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Tooling\MigrateInteropMiddleware;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MigrateInteropMiddlewareCommand extends Command
+{
+    private const DEFAULT_SRC = '/src';
+
+    private const HELP = <<< 'EOT'
+Migrate an Expressive application to PSR-15 middlewares.
+
+Scans all PHP files under the --src directory for interop middlewares
+and delegators. Changes imported interop classes to PSR-15 interfaces,
+keeps aliases and adds return type if it is not present.
+EOT;
+
+    private const HELP_OPT_SRC = <<< 'EOT'
+Specify a path to PHP files to migrate interop middlewares.
+If not specified, assumes src/ under the current working path.
+EOT;
+
+    /**
+     * @var null|string Path from which to resolve default src directory
+     */
+    private $projectDir;
+
+    /**
+     * @var null|string Project root against which to scan.
+     */
+    public function setProjectDir($path)
+    {
+        $this->projectDir = $path;
+    }
+
+    /**
+     * Retrieve the project root directory.
+     *
+     * Uses result of getcwd() if not previously set.
+     *
+     * @return string
+     */
+    private function getProjectDir()
+    {
+        return $this->projectDir ?: getcwd();
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Migrate interop middlewares and delegators');
+        $this->setHelp(self::HELP);
+        $this->addOption('src', 's', InputOption::VALUE_REQUIRED, self::HELP_OPT_SRC);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $src = $this->getSrcDir($input);
+
+        $output->writeln('<info>Scanning for usage of Interop Middlewares...</info>');
+
+        $converter = new ConvertInteropMiddleware($output);
+        $converter->process($src);
+
+//        if ($converter->originalResponseFound()) {
+//            $output->writeln('<error>One or more files contained calls to getOriginalResponse().</error>');
+//            $output->writeln('<info>Check the above logs to determine which files need attention.</info>');
+//            $output->writeln(self::TEMPLATE_RESPONSE_DETAILS);
+//        }
+
+        $output->writeln('<info>Done!</info>');
+
+        return 0;
+    }
+
+    /**
+     * @param InputInterface $input
+     * @return string
+     * @throws ArgvException
+     */
+    private function getSrcDir(InputInterface $input)
+    {
+        $path = $input->getOption('src') ?: self::DEFAULT_SRC;
+        $path = $this->getProjectDir() . '/' . $path;
+
+        if (! is_dir($path)) {
+            throw new ArgvException(sprintf(
+                'Invalid --src argument "%s"; directory does not exist',
+                $path
+            ));
+        }
+
+        return $path;
+    }
+}

--- a/src/MigrateInteropMiddleware/MigrateInteropMiddlewareCommand.php
+++ b/src/MigrateInteropMiddleware/MigrateInteropMiddlewareCommand.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/MigrateOriginalMessageCalls/ArgvException.php
+++ b/src/MigrateOriginalMessageCalls/ArgvException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/MigrateOriginalMessageCalls/ArgvException.php
+++ b/src/MigrateOriginalMessageCalls/ArgvException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\MigrateOriginalMessageCalls;
 
 use RuntimeException;

--- a/src/MigrateOriginalMessageCalls/ConvertOriginalMessageCalls.php
+++ b/src/MigrateOriginalMessageCalls/ConvertOriginalMessageCalls.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\MigrateOriginalMessageCalls;
 
 use RecursiveDirectoryIterator;

--- a/src/MigrateOriginalMessageCalls/ConvertOriginalMessageCalls.php
+++ b/src/MigrateOriginalMessageCalls/ConvertOriginalMessageCalls.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/MigrateOriginalMessageCalls/MigrateOriginalMessageCallsCommand.php
+++ b/src/MigrateOriginalMessageCalls/MigrateOriginalMessageCallsCommand.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/MigrateOriginalMessageCalls/MigrateOriginalMessageCallsCommand.php
+++ b/src/MigrateOriginalMessageCalls/MigrateOriginalMessageCallsCommand.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\MigrateOriginalMessageCalls;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/Module/CommandCommonOptions.php
+++ b/src/Module/CommandCommonOptions.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\Module;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/Module/CommandCommonOptions.php
+++ b/src/Module/CommandCommonOptions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Module/Create.php
+++ b/src/Module/Create.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Module/Create.php
+++ b/src/Module/Create.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\Module;
 
 use Zend\Expressive\Tooling\Module\Exception;

--- a/src/Module/CreateCommand.php
+++ b/src/Module/CreateCommand.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\Module;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/Module/CreateCommand.php
+++ b/src/Module/CreateCommand.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Module/DeregisterCommand.php
+++ b/src/Module/DeregisterCommand.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\Module;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/Module/DeregisterCommand.php
+++ b/src/Module/DeregisterCommand.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Module/Exception/RuntimeException.php
+++ b/src/Module/Exception/RuntimeException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Module/Exception/RuntimeException.php
+++ b/src/Module/Exception/RuntimeException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\Module\Exception;
 
 class RuntimeException extends \RuntimeException

--- a/src/Module/RegisterCommand.php
+++ b/src/Module/RegisterCommand.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\Module;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/Module/RegisterCommand.php
+++ b/src/Module/RegisterCommand.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/ScanForErrorMiddleware/ArgvException.php
+++ b/src/ScanForErrorMiddleware/ArgvException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/ScanForErrorMiddleware/ArgvException.php
+++ b/src/ScanForErrorMiddleware/ArgvException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\ScanForErrorMiddleware;
 
 use RuntimeException;

--- a/src/ScanForErrorMiddleware/ErrorMiddlewareFilter.php
+++ b/src/ScanForErrorMiddleware/ErrorMiddlewareFilter.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/ScanForErrorMiddleware/ErrorMiddlewareFilter.php
+++ b/src/ScanForErrorMiddleware/ErrorMiddlewareFilter.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\ScanForErrorMiddleware;
 
 use FilterIterator;

--- a/src/ScanForErrorMiddleware/NextInvocationScanner.php
+++ b/src/ScanForErrorMiddleware/NextInvocationScanner.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\ScanForErrorMiddleware;
 
 class NextInvocationScanner

--- a/src/ScanForErrorMiddleware/NextInvocationScanner.php
+++ b/src/ScanForErrorMiddleware/NextInvocationScanner.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/ScanForErrorMiddleware/ScanForErrorMiddlewareCommand.php
+++ b/src/ScanForErrorMiddleware/ScanForErrorMiddlewareCommand.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/ScanForErrorMiddleware/ScanForErrorMiddlewareCommand.php
+++ b/src/ScanForErrorMiddleware/ScanForErrorMiddlewareCommand.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\ScanForErrorMiddleware;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/ScanForErrorMiddleware/Scanner.php
+++ b/src/ScanForErrorMiddleware/Scanner.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/ScanForErrorMiddleware/Scanner.php
+++ b/src/ScanForErrorMiddleware/Scanner.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Tooling\ScanForErrorMiddleware;
 
 use Countable;

--- a/test/CreateMiddleware/CreateMiddlewareCommandTest.php
+++ b/test/CreateMiddleware/CreateMiddlewareCommandTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\CreateMiddleware;
 
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;

--- a/test/CreateMiddleware/CreateMiddlewareCommandTest.php
+++ b/test/CreateMiddleware/CreateMiddlewareCommandTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/CreateMiddleware/CreateMiddlewareExceptionTest.php
+++ b/test/CreateMiddleware/CreateMiddlewareExceptionTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\CreateMiddleware;
 
 use PHPUnit\Framework\TestCase;

--- a/test/CreateMiddleware/CreateMiddlewareExceptionTest.php
+++ b/test/CreateMiddleware/CreateMiddlewareExceptionTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/CreateMiddleware/CreateMiddlewareTest.php
+++ b/test/CreateMiddleware/CreateMiddlewareTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/CreateMiddleware/CreateMiddlewareTest.php
+++ b/test/CreateMiddleware/CreateMiddlewareTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\CreateMiddleware;
 
 use org\bovigo\vfs\vfsStream;

--- a/test/CreateMiddleware/CreateMiddlewareTest.php
+++ b/test/CreateMiddleware/CreateMiddlewareTest.php
@@ -136,7 +136,8 @@ class CreateMiddlewareTest extends TestCase
         $this->assertRegexp('#^namespace Foo;$#m', $classFileContents);
         $this->assertRegexp('#^class BarMiddleware implements MiddlewareInterface$#m', $classFileContents);
         $this->assertRegexp(
-            '#^\s{4}public function process\(ServerRequestInterface \$request, DelegateInterface \$delegate\)$#m',
+            '#^\s{4}public function process\(ServerRequestInterface \$request,'
+                . ' RequestHandlerInterface \$handler\) : ResponseInterface$#m',
             $classFileContents
         );
     }
@@ -166,7 +167,8 @@ class CreateMiddlewareTest extends TestCase
         $this->assertRegexp('#^namespace Foo\\\\Bar;$#m', $classFileContents);
         $this->assertRegexp('#^class BazMiddleware implements MiddlewareInterface$#m', $classFileContents);
         $this->assertRegexp(
-            '#^\s{4}public function process\(ServerRequestInterface \$request, DelegateInterface \$delegate\)$#m',
+            '#^\s{4}public function process\(ServerRequestInterface \$request,'
+                . ' RequestHandlerInterface \$handler\) : ResponseInterface$#m',
             $classFileContents
         );
     }
@@ -196,7 +198,8 @@ class CreateMiddlewareTest extends TestCase
         $this->assertRegexp('#^namespace Foo;$#m', $classFileContents);
         $this->assertRegexp('#^class BarMiddleware implements MiddlewareInterface$#m', $classFileContents);
         $this->assertRegexp(
-            '#^\s{4}public function process\(ServerRequestInterface \$request, DelegateInterface \$delegate\)$#m',
+            '#^\s{4}public function process\(ServerRequestInterface \$request,'
+                . ' RequestHandlerInterface \$handler\) : ResponseInterface$#m',
             $classFileContents
         );
     }
@@ -226,7 +229,8 @@ class CreateMiddlewareTest extends TestCase
         $this->assertRegexp('#^namespace Foo\\\\Bar;$#m', $classFileContents);
         $this->assertRegexp('#^class BazMiddleware implements MiddlewareInterface$#m', $classFileContents);
         $this->assertRegexp(
-            '#^\s{4}public function process\(ServerRequestInterface \$request, DelegateInterface \$delegate\)$#m',
+            '#^\s{4}public function process\(ServerRequestInterface \$request,'
+                . ' RequestHandlerInterface \$handler\) : ResponseInterface$#m',
             $classFileContents
         );
     }

--- a/test/GenerateProgrammaticPipelineFromConfig/GeneratorTest.php
+++ b/test/GenerateProgrammaticPipelineFromConfig/GeneratorTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/GenerateProgrammaticPipelineFromConfig/GeneratorTest.php
+++ b/test/GenerateProgrammaticPipelineFromConfig/GeneratorTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\GenerateProgrammaticPipelineFromConfig;
 
 use org\bovigo\vfs\vfsStream;

--- a/test/GenerateProgrammaticPipelineFromConfig/PipelineFromConfigCommandTest.php
+++ b/test/GenerateProgrammaticPipelineFromConfig/PipelineFromConfigCommandTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\GenerateProgrammaticPipelineFromConfig;
 
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;

--- a/test/GenerateProgrammaticPipelineFromConfig/PipelineFromConfigCommandTest.php
+++ b/test/GenerateProgrammaticPipelineFromConfig/PipelineFromConfigCommandTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/MigrateInteropMiddleware/ConvertInteropMiddlewareTest.php
+++ b/test/MigrateInteropMiddleware/ConvertInteropMiddlewareTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware;
 
 use org\bovigo\vfs\vfsStream;

--- a/test/MigrateInteropMiddleware/ConvertInteropMiddlewareTest.php
+++ b/test/MigrateInteropMiddleware/ConvertInteropMiddlewareTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Zend\Expressive\Tooling\MigrateInteropMiddleware\ConvertInteropMiddleware;
+
+class ConvertInteropMiddlewareTest extends TestCase
+{
+    use ProjectSetupTrait;
+
+    public function testConvertsFilesAndEmitsInfoMessagesAsExpected()
+    {
+        $dir = vfsStream::setup('migrate');
+        $this->setupSrcDir($dir);
+        $path = vfsStream::url('migrate');
+
+        $console = $this->setupConsoleHelper();
+
+        $converter = new ConvertInteropMiddleware($console->reveal());
+        $converter->process($path);
+
+        $this->assertExpected($path);
+    }
+}

--- a/test/MigrateInteropMiddleware/ConvertInteropMiddlewareTest.php
+++ b/test/MigrateInteropMiddleware/ConvertInteropMiddlewareTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/MigrateInteropMiddleware/MigrateInteropMiddlewareCommandTest.php
+++ b/test/MigrateInteropMiddleware/MigrateInteropMiddlewareCommandTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware;
 
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;

--- a/test/MigrateInteropMiddleware/MigrateInteropMiddlewareCommandTest.php
+++ b/test/MigrateInteropMiddleware/MigrateInteropMiddlewareCommandTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/MigrateInteropMiddleware/MigrateInteropMiddlewareCommandTest.php
+++ b/test/MigrateInteropMiddleware/MigrateInteropMiddlewareCommandTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware;
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use ReflectionClass;
+use ReflectionMethod;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Zend\Expressive\Tooling\MigrateInteropMiddleware\ArgvException;
+use Zend\Expressive\Tooling\MigrateInteropMiddleware\ConvertInteropMiddleware;
+use Zend\Expressive\Tooling\MigrateInteropMiddleware\MigrateInteropMiddlewareCommand;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class MigrateInteropMiddlewareCommandTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /** @var InputInterface|ObjectProphecy */
+    private $input;
+
+    /** @var ConsoleOutputInterface|ObjectProphecy */
+    private $output;
+
+    /** @var MigrateInteropMiddlewareCommand */
+    private $command;
+
+    protected function setUp()
+    {
+        $this->input = $this->prophesize(InputInterface::class);
+        $this->output = $this->prophesize(ConsoleOutputInterface::class);
+
+        $this->command = new MigrateInteropMiddlewareCommand('migrate:interop-middlewares');
+    }
+
+    private function reflectExecuteMethod()
+    {
+        $r = new ReflectionMethod($this->command, 'execute');
+        $r->setAccessible(true);
+        return $r;
+    }
+
+    public function testConfigureSetsExpectedDescription()
+    {
+        $this->assertContains('Migrate interop middlewares and delegators', $this->command->getDescription());
+    }
+
+    private function getConstantValue(string $const, string $class = MigrateInteropMiddlewareCommand::class)
+    {
+        $r = new ReflectionClass($class);
+
+        return $r->getConstant($const);
+    }
+
+    public function testConfigureSetsExpectedHelp()
+    {
+        $this->assertEquals($this->getConstantValue('HELP'), $this->command->getHelp());
+    }
+
+    public function testConfigureSetsExpectedArguments()
+    {
+        $definition = $this->command->getDefinition();
+        $this->assertTrue($definition->hasOption('src'));
+        $option = $definition->getOption('src');
+        $this->assertTrue($option->isValueRequired());
+        $this->assertEquals($this->getConstantValue('HELP_OPT_SRC'), $option->getDescription());
+    }
+
+    public function testSuccessfulExecutionEmitsExpectedMessages()
+    {
+        vfsStream::setup('migrate');
+        $path = vfsStream::url('migrate');
+        mkdir($path . '/src');
+
+        $converter = Mockery::mock('overload:' . ConvertInteropMiddleware::class);
+        $converter->shouldReceive('process')
+            ->once()
+            ->with($path . '/src')
+            ->andReturnNull();
+
+        $this->input->getOption('src')->willReturn('src');
+
+        $this->output
+            ->writeln(Argument::containingString('Scanning for usage of Interop Middlewares...'))
+            ->shouldBeCalled();
+        $this->output
+            ->writeln(Argument::containingString('Done!'))
+            ->shouldBeCalled();
+
+        $this->command->setProjectDir($path);
+        $method = $this->reflectExecuteMethod();
+
+        $this->assertSame(0, $method->invoke(
+            $this->command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+    }
+
+    public function testAllowsExceptionsFromInvalidSrcDirectoryArgumentToBubbleUp()
+    {
+        vfsStream::setup('migrate');
+        $path = vfsStream::url('migrate');
+
+        $converter = Mockery::mock('overload:' . ConvertInteropMiddleware::class);
+        $converter->shouldNotReceive('process');
+
+        $this->input->getOption('src')->willReturn('src');
+
+        $this->command->setProjectDir($path);
+        $method = $this->reflectExecuteMethod();
+
+        $this->expectException(ArgvException::class);
+        $this->expectExceptionMessage('Invalid --src argument');
+
+        $method->invoke(
+            $this->command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        );
+    }
+}

--- a/test/MigrateInteropMiddleware/ProjectSetupTrait.php
+++ b/test/MigrateInteropMiddleware/ProjectSetupTrait.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware;
 
 use org\bovigo\vfs\vfsStream;

--- a/test/MigrateInteropMiddleware/ProjectSetupTrait.php
+++ b/test/MigrateInteropMiddleware/ProjectSetupTrait.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/MigrateInteropMiddleware/ProjectSetupTrait.php
+++ b/test/MigrateInteropMiddleware/ProjectSetupTrait.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\Assert;
+use Prophecy\Argument;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use Symfony\Component\Console\Output\OutputInterface;
+
+trait ProjectSetupTrait
+{
+    public function setupSrcDir($dir)
+    {
+        $base = realpath(__DIR__ . '/TestAsset') . DIRECTORY_SEPARATOR;
+        $rdi = new RecursiveDirectoryIterator($base . 'src');
+        $rii = new RecursiveIteratorIterator($rdi);
+
+        foreach ($rii as $file) {
+            if (! $this->isPhpFile($file)) {
+                continue;
+            }
+
+            $filename = $file->getRealPath();
+            $contents = file_get_contents($filename);
+            $name = strtr($filename, [$base => '', DIRECTORY_SEPARATOR => '/']);
+            vfsStream::newFile($name)
+                ->at($dir)
+                ->setContent($contents);
+        }
+    }
+
+    public function isPhpFile(SplFileInfo $file)
+    {
+        return $file->isFile()
+            && $file->getExtension() === 'php'
+            && $file->isReadable()
+            && $file->isWritable();
+    }
+
+    public function setupConsoleHelper()
+    {
+        $console = $this->prophesize(OutputInterface::class);
+
+        $console
+            ->writeln(Argument::containingString('src/InteropAliasMiddleware.php'))
+            ->shouldBeCalled();
+        $console
+            ->writeln(Argument::containingString('src/MultilineMiddleware.php'))
+            ->shouldBeCalled();
+        $console
+            ->writeln(Argument::containingString('src/MultipleInterfacesMiddleware.php'))
+            ->shouldBeCalled();
+        $console
+            ->writeln(Argument::containingString('src/MyInteropDelegate.php'))
+            ->shouldBeCalled();
+        $console
+            ->writeln(Argument::containingString('src/MyInteropMiddleware.php'))
+            ->shouldBeCalled();
+
+        return $console;
+    }
+
+    public function assertExpected(string $dir)
+    {
+        $base = $dir;
+        $rdi = new RecursiveDirectoryIterator($dir);
+        $rii = new RecursiveIteratorIterator($rdi);
+
+        /** @var SplFileInfo $file */
+        foreach ($rii as $file) {
+            if (! $this->isPhpFile($file)) {
+                continue;
+            }
+
+            $filename = $file->getPathname();
+            $content = file_get_contents($filename);
+            $name = strtr($filename, [$base . '/src' => __DIR__ . '/TestAsset/expected', DIRECTORY_SEPARATOR => '/']);
+
+            Assert::assertSame(file_get_contents($name), $content);
+        }
+    }
+}

--- a/test/MigrateInteropMiddleware/TestAsset/expected/InteropAliasMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/expected/InteropAliasMiddleware.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
+
+use Interop\Http\Server\RequestHandlerInterface as Handler;
+use Interop\Http\Server\MiddlewareInterface as ServerMiddleware;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface;
+
+class InteropAliasMiddleware implements ServerMiddleware
+{
+    public function process(ServerRequestInterface $request, Handler $handler) : Response
+    {
+        // do something
+    }
+}

--- a/test/MigrateInteropMiddleware/TestAsset/expected/MultilineMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/expected/MultilineMiddleware.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
+
+use Interop\Http\Server\RequestHandlerInterface as DelegateInterface;
+use Interop\Http\Server\MiddlewareInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class MultilineMiddleware implements MiddlewareInterface
+{
+    public function process(
+        ServerRequestInterface $request,
+        DelegateInterface $delegate
+    ) : \Psr\Http\Message\ResponseInterface {
+        // do something
+    }
+}

--- a/test/MigrateInteropMiddleware/TestAsset/expected/MultilineMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/expected/MultilineMiddleware.php
@@ -12,6 +12,6 @@ class MultilineMiddleware implements MiddlewareInterface
         ServerRequestInterface $request,
         DelegateInterface $delegate
     ) : \Psr\Http\Message\ResponseInterface {
-        // do something
+        return $delegate->handle($request);
     }
 }

--- a/test/MigrateInteropMiddleware/TestAsset/expected/MultipleInterfacesMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/expected/MultipleInterfacesMiddleware.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
+
+use Interop\Http\Server\RequestHandlerInterface as DelegateInterface;
+use Interop\Http\Server\MiddlewareInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class MultipleInterfacesMiddleware implements
+    MyInterface,
+    MiddlewareInterface,
+    SomeInterface
+{
+    /**
+     * @param ServerRequestInterface $request
+     * @param DelegateInterface $delegate
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate) : ResponseInterface {
+        // do something
+    }
+}

--- a/test/MigrateInteropMiddleware/TestAsset/expected/MultipleInterfacesMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/expected/MultipleInterfacesMiddleware.php
@@ -6,6 +6,7 @@ use Interop\Http\Server\RequestHandlerInterface as DelegateInterface;
 use Interop\Http\Server\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response\JsonResponse;
 
 class MultipleInterfacesMiddleware implements
     MyInterface,
@@ -18,6 +19,10 @@ class MultipleInterfacesMiddleware implements
      * @return ResponseInterface
      */
     public function process(ServerRequestInterface $request, DelegateInterface $delegate) : ResponseInterface {
-        // do something
+        if ($request->hasHeader('Custom')) {
+            return $delegate->handle($request);
+        }
+
+        return new JsonResponse(['status' => 1]);
     }
 }

--- a/test/MigrateInteropMiddleware/TestAsset/expected/MyClass.php
+++ b/test/MigrateInteropMiddleware/TestAsset/expected/MyClass.php
@@ -11,7 +11,7 @@ class MyClass
     {
     }
 
-    public function delegate(ServerRequestInterface $request)
+    public function handle(ServerRequestInterface $request)
     {
     }
 }

--- a/test/MigrateInteropMiddleware/TestAsset/expected/MyClass.php
+++ b/test/MigrateInteropMiddleware/TestAsset/expected/MyClass.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
+
+use Interop\Http\Server\RequestHandlerInterface as Handler;
+use Psr\Http\Message\ServerRequestInterface;
+
+class MyClass
+{
+    public function process(ServerRequestInterface $request, Handler $handler)
+    {
+    }
+
+    public function delegate(ServerRequestInterface $request)
+    {
+    }
+}

--- a/test/MigrateInteropMiddleware/TestAsset/expected/MyInteropDelegate.php
+++ b/test/MigrateInteropMiddleware/TestAsset/expected/MyInteropDelegate.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
+
+use Interop\Http\Server\RequestHandlerInterface as DelegateInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class MyInteropDelegate implements DelegateInterface
+{
+    public function handle(ServerRequestInterface $request) : \Psr\Http\Message\ResponseInterface
+    {
+    }
+}

--- a/test/MigrateInteropMiddleware/TestAsset/expected/MyInteropMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/expected/MyInteropMiddleware.php
@@ -10,6 +10,11 @@ class MyInteropMiddleware implements MiddlewareInterface
 {
     public function process(ServerRequestInterface $request, DelegateInterface $delegate) : \Psr\Http\Message\ResponseInterface
     {
-        // do something
+        $response = $delegate->handle($request);
+
+        $another = $request->getAttribute('my-attribute');
+        $another->process($request);
+
+        return $response;
     }
 }

--- a/test/MigrateInteropMiddleware/TestAsset/expected/MyInteropMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/expected/MyInteropMiddleware.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
+
+use Interop\Http\Server\RequestHandlerInterface as DelegateInterface;
+use Interop\Http\Server\MiddlewareInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class MyInteropMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate) : \Psr\Http\Message\ResponseInterface
+    {
+        // do something
+    }
+}

--- a/test/MigrateInteropMiddleware/TestAsset/src/InteropAliasMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/InteropAliasMiddleware.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
+
+use Interop\Http\ServerMiddleware\DelegateInterface as Handler;
+use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddleware;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface;
+
+class InteropAliasMiddleware implements ServerMiddleware
+{
+    public function process(ServerRequestInterface $request, Handler $handler)
+    {
+        // do something
+    }
+}

--- a/test/MigrateInteropMiddleware/TestAsset/src/MultilineMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/MultilineMiddleware.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
+
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class MultilineMiddleware implements MiddlewareInterface
+{
+    public function process(
+        ServerRequestInterface $request,
+        DelegateInterface $delegate
+    ) {
+        // do something
+    }
+}

--- a/test/MigrateInteropMiddleware/TestAsset/src/MultilineMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/MultilineMiddleware.php
@@ -12,6 +12,6 @@ class MultilineMiddleware implements MiddlewareInterface
         ServerRequestInterface $request,
         DelegateInterface $delegate
     ) {
-        // do something
+        return $delegate->process($request);
     }
 }

--- a/test/MigrateInteropMiddleware/TestAsset/src/MultipleInterfacesMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/MultipleInterfacesMiddleware.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
+
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class MultipleInterfacesMiddleware implements
+    MyInterface,
+    MiddlewareInterface,
+    SomeInterface
+{
+    /**
+     * @param ServerRequestInterface $request
+     * @param DelegateInterface $delegate
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate) {
+        // do something
+    }
+}

--- a/test/MigrateInteropMiddleware/TestAsset/src/MultipleInterfacesMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/MultipleInterfacesMiddleware.php
@@ -6,6 +6,7 @@ use Interop\Http\ServerMiddleware\DelegateInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response\JsonResponse;
 
 class MultipleInterfacesMiddleware implements
     MyInterface,
@@ -18,6 +19,10 @@ class MultipleInterfacesMiddleware implements
      * @return ResponseInterface
      */
     public function process(ServerRequestInterface $request, DelegateInterface $delegate) {
-        // do something
+        if ($request->hasHeader('Custom')) {
+            return $delegate->process($request);
+        }
+
+        return new JsonResponse(['status' => 1]);
     }
 }

--- a/test/MigrateInteropMiddleware/TestAsset/src/MyClass.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/MyClass.php
@@ -11,7 +11,7 @@ class MyClass
     {
     }
 
-    public function delegate(ServerRequestInterface $request)
+    public function handle(ServerRequestInterface $request)
     {
     }
 }

--- a/test/MigrateInteropMiddleware/TestAsset/src/MyClass.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/MyClass.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
+
+use Interop\Http\Server\RequestHandlerInterface as Handler;
+use Psr\Http\Message\ServerRequestInterface;
+
+class MyClass
+{
+    public function process(ServerRequestInterface $request, Handler $handler)
+    {
+    }
+
+    public function delegate(ServerRequestInterface $request)
+    {
+    }
+}

--- a/test/MigrateInteropMiddleware/TestAsset/src/MyInteropDelegate.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/MyInteropDelegate.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
+
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class MyInteropDelegate implements DelegateInterface
+{
+    public function delegate(ServerRequestInterface $request)
+    {
+    }
+}

--- a/test/MigrateInteropMiddleware/TestAsset/src/MyInteropDelegate.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/MyInteropDelegate.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class MyInteropDelegate implements DelegateInterface
 {
-    public function delegate(ServerRequestInterface $request)
+    public function process(ServerRequestInterface $request)
     {
     }
 }

--- a/test/MigrateInteropMiddleware/TestAsset/src/MyInteropMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/MyInteropMiddleware.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
+
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class MyInteropMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    {
+        // do something
+    }
+}

--- a/test/MigrateInteropMiddleware/TestAsset/src/MyInteropMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/MyInteropMiddleware.php
@@ -10,6 +10,11 @@ class MyInteropMiddleware implements MiddlewareInterface
 {
     public function process(ServerRequestInterface $request, DelegateInterface $delegate)
     {
-        // do something
+        $response = $delegate->process($request);
+
+        $another = $request->getAttribute('my-attribute');
+        $another->process($request);
+
+        return $response;
     }
 }

--- a/test/MigrateOriginalMessageCalls/ConvertOriginalMessageCallsTest.php
+++ b/test/MigrateOriginalMessageCalls/ConvertOriginalMessageCallsTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/MigrateOriginalMessageCalls/ConvertOriginalMessageCallsTest.php
+++ b/test/MigrateOriginalMessageCalls/ConvertOriginalMessageCallsTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\MigrateOriginalMessageCalls;
 
 use org\bovigo\vfs\vfsStream;

--- a/test/MigrateOriginalMessageCalls/ConvertOriginalMessageCallsTest.php
+++ b/test/MigrateOriginalMessageCalls/ConvertOriginalMessageCallsTest.php
@@ -25,5 +25,7 @@ class ConvertOriginalMessageCallsTest extends TestCase
 
         $converter = new ConvertOriginalMessageCalls($console->reveal());
         $converter->process($path);
+
+        $this->assertExpected($path);
     }
 }

--- a/test/MigrateOriginalMessageCalls/MigrateOriginalMessageCallsCommandTest.php
+++ b/test/MigrateOriginalMessageCalls/MigrateOriginalMessageCallsCommandTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\MigrateOriginalMessageCalls;
 
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;

--- a/test/MigrateOriginalMessageCalls/MigrateOriginalMessageCallsCommandTest.php
+++ b/test/MigrateOriginalMessageCalls/MigrateOriginalMessageCallsCommandTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/MigrateOriginalMessageCalls/ProjectSetupTrait.php
+++ b/test/MigrateOriginalMessageCalls/ProjectSetupTrait.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/MigrateOriginalMessageCalls/ProjectSetupTrait.php
+++ b/test/MigrateOriginalMessageCalls/ProjectSetupTrait.php
@@ -8,6 +8,7 @@
 namespace ZendTest\Expressive\Tooling\MigrateOriginalMessageCalls;
 
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\Assert;
 use Prophecy\Argument;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -69,5 +70,25 @@ trait ProjectSetupTrait
             ->shouldBeCalled();
 
         return $console;
+    }
+
+    public function assertExpected(string $dir)
+    {
+        $base = $dir;
+        $rdi = new RecursiveDirectoryIterator($dir);
+        $rii = new RecursiveIteratorIterator($rdi);
+
+        /** @var SplFileInfo $file */
+        foreach ($rii as $file) {
+            if (! $this->isPhpFile($file)) {
+                continue;
+            }
+
+            $filename = $file->getPathname();
+            $content = file_get_contents($filename);
+            $name = strtr($filename, [$base . '/src' => __DIR__ . '/TestAsset/expected', DIRECTORY_SEPARATOR => '/']);
+
+            Assert::assertSame(file_get_contents($name), $content);
+        }
     }
 }

--- a/test/MigrateOriginalMessageCalls/ProjectSetupTrait.php
+++ b/test/MigrateOriginalMessageCalls/ProjectSetupTrait.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\MigrateOriginalMessageCalls;
 
 use org\bovigo\vfs\vfsStream;

--- a/test/MigrateOriginalMessageCalls/TestAsset/expected/FileContainingOriginalRequest.php
+++ b/test/MigrateOriginalMessageCalls/TestAsset/expected/FileContainingOriginalRequest.php
@@ -5,4 +5,6 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 $original = $request->getAttribute('originalRequest', $request);

--- a/test/MigrateOriginalMessageCalls/TestAsset/expected/FileContainingOriginalRequest.php
+++ b/test/MigrateOriginalMessageCalls/TestAsset/expected/FileContainingOriginalRequest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/MigrateOriginalMessageCalls/TestAsset/expected/FileContainingOriginalUri.php
+++ b/test/MigrateOriginalMessageCalls/TestAsset/expected/FileContainingOriginalUri.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/MigrateOriginalMessageCalls/TestAsset/expected/FileContainingOriginalUri.php
+++ b/test/MigrateOriginalMessageCalls/TestAsset/expected/FileContainingOriginalUri.php
@@ -5,4 +5,6 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 $originalUri = $request->getAttribute('originalUri', $request->getUri());

--- a/test/MigrateOriginalMessageCalls/TestAsset/expected/subdir/FileContainingOriginalResponse.php
+++ b/test/MigrateOriginalMessageCalls/TestAsset/expected/subdir/FileContainingOriginalResponse.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/MigrateOriginalMessageCalls/TestAsset/expected/subdir/FileContainingOriginalResponse.php
+++ b/test/MigrateOriginalMessageCalls/TestAsset/expected/subdir/FileContainingOriginalResponse.php
@@ -5,4 +5,6 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 $original = $response->getOriginalResponse();

--- a/test/MigrateOriginalMessageCalls/TestAsset/expected/subdir/nested/FileContainingManyStatements.php
+++ b/test/MigrateOriginalMessageCalls/TestAsset/expected/subdir/nested/FileContainingManyStatements.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/MigrateOriginalMessageCalls/TestAsset/expected/subdir/nested/FileContainingManyStatements.php
+++ b/test/MigrateOriginalMessageCalls/TestAsset/expected/subdir/nested/FileContainingManyStatements.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 $originalPath = $request->getAttribute('originalRequest', $request)->getUri()->getPath();
 
 $middleware = function ($req, $res, $next) {

--- a/test/MigrateOriginalMessageCalls/TestAsset/src/FileContainingOriginalRequest.php
+++ b/test/MigrateOriginalMessageCalls/TestAsset/src/FileContainingOriginalRequest.php
@@ -5,4 +5,6 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 $original = $request->getOriginalRequest();

--- a/test/MigrateOriginalMessageCalls/TestAsset/src/FileContainingOriginalRequest.php
+++ b/test/MigrateOriginalMessageCalls/TestAsset/src/FileContainingOriginalRequest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/MigrateOriginalMessageCalls/TestAsset/src/FileContainingOriginalUri.php
+++ b/test/MigrateOriginalMessageCalls/TestAsset/src/FileContainingOriginalUri.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/MigrateOriginalMessageCalls/TestAsset/src/FileContainingOriginalUri.php
+++ b/test/MigrateOriginalMessageCalls/TestAsset/src/FileContainingOriginalUri.php
@@ -5,4 +5,6 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 $originalUri = $request->getOriginalUri();

--- a/test/MigrateOriginalMessageCalls/TestAsset/src/subdir/FileContainingOriginalResponse.php
+++ b/test/MigrateOriginalMessageCalls/TestAsset/src/subdir/FileContainingOriginalResponse.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/MigrateOriginalMessageCalls/TestAsset/src/subdir/FileContainingOriginalResponse.php
+++ b/test/MigrateOriginalMessageCalls/TestAsset/src/subdir/FileContainingOriginalResponse.php
@@ -5,4 +5,6 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 $original = $response->getOriginalResponse();

--- a/test/MigrateOriginalMessageCalls/TestAsset/src/subdir/nested/FileContainingManyStatements.php
+++ b/test/MigrateOriginalMessageCalls/TestAsset/src/subdir/nested/FileContainingManyStatements.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/MigrateOriginalMessageCalls/TestAsset/src/subdir/nested/FileContainingManyStatements.php
+++ b/test/MigrateOriginalMessageCalls/TestAsset/src/subdir/nested/FileContainingManyStatements.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 $originalPath = $request->getOriginalRequest()->getUri()->getPath();
 
 $middleware = function ($req, $res, $next) {

--- a/test/Module/CommonOptionsAndAttributesTrait.php
+++ b/test/Module/CommonOptionsAndAttributesTrait.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Module/CommonOptionsAndAttributesTrait.php
+++ b/test/Module/CommonOptionsAndAttributesTrait.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\Module;
 
 trait CommonOptionsAndAttributesTrait

--- a/test/Module/CreateCommandTest.php
+++ b/test/Module/CreateCommandTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Module/CreateCommandTest.php
+++ b/test/Module/CreateCommandTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\Module;
 
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;

--- a/test/Module/CreateTest.php
+++ b/test/Module/CreateTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\Module;
 
 use org\bovigo\vfs\vfsStream;

--- a/test/Module/CreateTest.php
+++ b/test/Module/CreateTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Module/DeregisterCommandTest.php
+++ b/test/Module/DeregisterCommandTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\Module;
 
 use Mockery;

--- a/test/Module/DeregisterCommandTest.php
+++ b/test/Module/DeregisterCommandTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Module/RegisterCommandTest.php
+++ b/test/Module/RegisterCommandTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\Module;
 
 use Mockery;

--- a/test/Module/RegisterCommandTest.php
+++ b/test/Module/RegisterCommandTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/ScanForErrorMiddleware/ErrorMiddlewareFilterTest.php
+++ b/test/ScanForErrorMiddleware/ErrorMiddlewareFilterTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/ScanForErrorMiddleware/ErrorMiddlewareFilterTest.php
+++ b/test/ScanForErrorMiddleware/ErrorMiddlewareFilterTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\ScanForErrorMiddleware;
 
 use ArrayIterator;

--- a/test/ScanForErrorMiddleware/NextInvocationScannerTest.php
+++ b/test/ScanForErrorMiddleware/NextInvocationScannerTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/ScanForErrorMiddleware/NextInvocationScannerTest.php
+++ b/test/ScanForErrorMiddleware/NextInvocationScannerTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\ScanForErrorMiddleware;
 
 use PHPUnit\Framework\TestCase;

--- a/test/ScanForErrorMiddleware/ScanForErrorMiddlewareCommandTest.php
+++ b/test/ScanForErrorMiddleware/ScanForErrorMiddlewareCommandTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\ScanForErrorMiddleware;
 
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;

--- a/test/ScanForErrorMiddleware/ScanForErrorMiddlewareCommandTest.php
+++ b/test/ScanForErrorMiddleware/ScanForErrorMiddlewareCommandTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/ScanForErrorMiddleware/ScannerTest.php
+++ b/test/ScanForErrorMiddleware/ScannerTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/ScanForErrorMiddleware/ScannerTest.php
+++ b/test/ScanForErrorMiddleware/ScannerTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Tooling\ScanForErrorMiddleware;
 
 use Countable;


### PR DESCRIPTION
- dropped PHP 5.6 and 7.0
- updated Travis CI config

Requires:
- [x] https://github.com/zendframework/zend-expressive-router/pull/39
- [x] https://github.com/zendframework/zend-expressive/pull/529
- [x] https://github.com/zendframework/zend-stratigility/pull/122

Added new tool: `migrate:interop-middleware` which will look for old http-interop/http-middleware style middlewares and delegators and update them to http-interop/http-server-middleware:
- updates namespaces and names of interfaces:
  - `Interop\Http\ServerMiddleware\MiddlewareInterface` -> `Interop\Http\Server\MiddlewareInterface`
  - `Interop\Http\ServerMiddleware\DelegateInterface` -> `Interop\Http\Server\RequestHandlerInterface`
- changes name method in delegators/handlers: `process` -> `handle`,
- changes `process` calls on delegator to `handle` (in middlewares),
- adds return type on methods `process` (in middleware) and `handle` (in request handler): `\Psr\Http\Message\ResponseInterface`.

**Fixed `migrate:original-messages` tests** - asserting expected files contents with output from converter