### PR TITLE
Implements new command "handler:create"

### DIFF
--- a/bin/expressive
+++ b/bin/expressive
@@ -30,6 +30,7 @@ if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
 
 $application = new Application('expressive', VERSION);
 $application->addCommands([
+    new CreateHandler\CreateHandlerCommand('handler:create'),
     new CreateMiddleware\CreateMiddlewareCommand('middleware:create'),
     new MigrateInteropMiddleware\MigrateInteropMiddlewareCommand('migrate:interop-middleware'),
     new Module\CreateCommand('module:create'),

--- a/src/CreateHandler/CreateHandler.php
+++ b/src/CreateHandler/CreateHandler.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Tooling\CreateHandler;
+
+/**
+ * Create a request handler
+ *
+ * Creates a request handler class file for a given class in a given project root.
+ */
+class CreateHandler
+{
+    /**
+     * @var string Template for request handler class.
+     */
+    const CLASS_SKELETON = <<< 'EOS'
+<?php
+
+namespace %namespace%;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class %class% implements RequestHandlerInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        // Create and return a response
+    }
+}
+EOS;
+
+    /**
+     * @param string $class
+     * @param string|null $projectRoot
+     * @param string $classSkeleton
+     * @return string
+     * @throws CreateHandlerException
+     */
+    public function process($class, $projectRoot = null, $classSkeleton = self::CLASS_SKELETON)
+    {
+        $projectRoot = $projectRoot ?: getcwd();
+
+        $path = $this->getClassPath($class, $projectRoot);
+
+        list($namespace, $class) = $this->getNamespaceAndClass($class);
+
+        $content = str_replace(
+            ['%namespace%', '%class%'],
+            [$namespace, $class],
+            $classSkeleton
+        );
+
+        if (is_file($path)) {
+            throw CreateHandlerException::classExists($path, $class);
+        }
+
+        file_put_contents($path, $content);
+        return $path;
+    }
+
+    /**
+     * @param string $class
+     * @param string $projectRoot
+     * @return string
+     * @throws CreateHandlerException
+     */
+    private function getClassPath($class, $projectRoot)
+    {
+        $autoloaders = $this->getComposerAutoloaders($projectRoot);
+        list($namespace, $path) = $this->discoverNamespaceAndPath($class, $autoloaders);
+
+        // Absolute path to namespace
+        $path = implode([$projectRoot, DIRECTORY_SEPARATOR, $path]);
+
+        $parts = explode('\\', $class);
+        $className = array_pop($parts);
+
+        // Create absolute path to subnamespace, if required
+        $nsParts = explode('\\', trim($namespace, '\\'));
+        $subNsParts = array_slice($parts, count($nsParts));
+
+        if (0 < count($subNsParts)) {
+            $subNsPath = implode(DIRECTORY_SEPARATOR, $subNsParts);
+            $path = implode([$path, DIRECTORY_SEPARATOR, $subNsPath]);
+        }
+
+        // Create path if it does not exist
+        if (! is_dir($path)) {
+            if (false === mkdir($path, 0755, true)) {
+                throw CreateHandlerException::unableToCreatePath($path, $class);
+            }
+        }
+
+        return $path . DIRECTORY_SEPARATOR . $className . '.php';
+    }
+
+    /**
+     * @param string $projectRoot
+     * @return array Associative array of namespace/path pairs
+     * @throws CreateHandlerException
+     */
+    private function getComposerAutoloaders($projectRoot)
+    {
+        $composerPath = sprintf('%s/composer.json', $projectRoot);
+        if (! file_exists($composerPath)) {
+            throw CreateHandlerException::missingComposerJson();
+        }
+
+        $composer = json_decode(file_get_contents($composerPath), true);
+
+        if (json_last_error() !== \JSON_ERROR_NONE) {
+            throw CreateHandlerException::invalidComposerJson(json_last_error_msg());
+        }
+
+        if (! isset($composer['autoload']['psr-4'])) {
+            throw CreateHandlerException::missingComposerAutoloaders();
+        }
+
+        if (! is_array($composer['autoload']['psr-4'])) {
+            throw CreateHandlerException::missingComposerAutoloaders();
+        }
+
+        return $composer['autoload']['psr-4'];
+    }
+
+    /**
+     * @param string $class
+     * @param array $autoloaders
+     * @return array [namespace, path]
+     * @throws CreateHandlerException
+     */
+    private function discoverNamespaceAndPath($class, array $autoloaders)
+    {
+        foreach ($autoloaders as $namespace => $path) {
+            if (0 === strpos($class, $namespace)) {
+                $path = trim(
+                    str_replace(
+                        ['/', '\\'],
+                        DIRECTORY_SEPARATOR,
+                        $path
+                    ),
+                    DIRECTORY_SEPARATOR
+                );
+                return [$namespace, $path];
+            }
+        }
+
+        throw CreateHandlerException::autoloaderNotFound($class);
+    }
+
+    /**
+     * @param string $class
+     * @return array [namespace, class]
+     */
+    private function getNamespaceAndClass($class)
+    {
+        $parts = explode('\\', $class);
+        $className = array_pop($parts);
+        $namespace = implode('\\', $parts);
+        return [$namespace, $className];
+    }
+}

--- a/src/CreateHandler/CreateHandlerCommand.php
+++ b/src/CreateHandler/CreateHandlerCommand.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Tooling\CreateHandler;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CreateHandlerCommand extends Command
+{
+    const DEFAULT_SRC = '/src';
+
+    const HELP = <<< 'EOT'
+Creates a PSR-15 request handler class file named after the provided
+class. For a path, it matches the class namespace against PSR-4 autoloader
+namespaces in your composer.json.
+EOT;
+
+    const HELP_ARG_HANDLER = <<< 'EOT'
+Fully qualified class name of the request handler to create. This value
+should be quoted to ensure namespace separators are not interpreted as
+escape sequences by your shell.
+EOT;
+
+    /**
+     * Configure the console command.
+     */
+    protected function configure()
+    {
+        $this->setDescription('Create a PSR-15 request handler class file.');
+        $this->setHelp(self::HELP);
+        $this->addArgument('handler', InputArgument::REQUIRED, self::HELP_ARG_HANDLER);
+    }
+
+    /**
+     * Execute console command.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int Exit status
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $handler = $input->getArgument('handler');
+
+        $output->writeln(sprintf('<info>Creating request handler %s...</info>', $handler));
+
+        $generator = new CreateHandler();
+        $path = $generator->process($handler);
+
+        $output->writeln('<info>Success!</info>');
+        $output->writeln(sprintf(
+            '<info>- Created class %s, in file %s</info>',
+            $handler,
+            $path
+        ));
+
+        return 0;
+    }
+}

--- a/src/CreateHandler/CreateHandlerException.php
+++ b/src/CreateHandler/CreateHandlerException.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Tooling\CreateHandler;
+
+use RuntimeException;
+
+class CreateHandlerException extends RuntimeException
+{
+    /**
+     * @return self
+     */
+    public static function missingComposerJson()
+    {
+        return new self('Could not find a composer.json in the project root');
+    }
+
+    /**
+     * @param string $error Error string related to JSON_ERROR_* constant
+     * @return self
+     */
+    public static function invalidComposerJson($error)
+    {
+        return new self(sprintf(
+            'Unable to parse composer.json: %s',
+            $error
+        ));
+    }
+
+    /**
+     * @return self
+     */
+    public static function missingComposerAutoloaders()
+    {
+        return new self('composer.json does not define any PSR-4 autoloaders');
+    }
+
+    /**
+     * @param string $class
+     * @return self
+     */
+    public static function autoloaderNotFound($class)
+    {
+        return new self(sprintf(
+            'Unable to match %s to an autoloadable PSR-4 namespace',
+            $class
+        ));
+    }
+
+    /**
+     * @param string $path
+     * @param string $class
+     * @return self
+     */
+    public static function unableToCreatePath($path, $class)
+    {
+        return new self(sprintf(
+            'Unable to create the directory %s for creating the class %s',
+            $path,
+            $class
+        ));
+    }
+
+    /**
+     * @param string $path
+     * @param string $class
+     * @return self
+     */
+    public static function classExists($path, $class)
+    {
+        return new self(sprintf(
+            'Class %s already exists in directory %s',
+            $class,
+            $path
+        ));
+    }
+}

--- a/src/CreateMiddleware/CreateMiddlewareCommand.php
+++ b/src/CreateMiddleware/CreateMiddlewareCommand.php
@@ -18,23 +18,10 @@ class CreateMiddlewareCommand extends Command
 {
     const DEFAULT_SRC = '/src';
 
-    const TEMPLATE_RESPONSE_DETAILS = <<< 'EOT'
-To correct these files, look for a request argument, and update the
-following calls ($response may be a different variable):
-
-    $response->getOriginalResponse()
-
-to:
-
-    $request->getAttribute('originalResponse', $response)
-
-($request may be a different variable)
-EOT;
-
     const HELP = <<< 'EOT'
-Creates an http-interop middleware class file named after the provided
-class. For a path, it matches the class namespace against PSR-4 autoloader
-namespaces in your composer.json.
+Creates a PSR-15 middleware class file named after the provided class. For a
+path, it matches the class namespace against PSR-4 autoloader namespaces in
+your composer.json.
 EOT;
 
     const HELP_ARG_MIDDLEWARE = <<< 'EOT'
@@ -48,7 +35,7 @@ EOT;
      */
     protected function configure()
     {
-        $this->setDescription('Create an http-interop middleware class file.');
+        $this->setDescription('Create a PSR-15 middleware class file.');
         $this->setHelp(self::HELP);
         $this->addArgument('middleware', InputArgument::REQUIRED, self::HELP_ARG_MIDDLEWARE);
     }

--- a/test/CreateHandler/CreateHandlerCommandTest.php
+++ b/test/CreateHandler/CreateHandlerCommandTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Tooling\CreateHandler;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use ReflectionMethod;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Zend\Expressive\Tooling\CreateHandler\CreateHandler;
+use Zend\Expressive\Tooling\CreateHandler\CreateHandlerCommand;
+use Zend\Expressive\Tooling\CreateHandler\CreateHandlerException;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class CreateHandlerCommandTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected function setUp()
+    {
+        $this->input = $this->prophesize(InputInterface::class);
+        $this->output = $this->prophesize(ConsoleOutputInterface::class);
+
+        $this->command = new CreateHandlerCommand('handler:create');
+    }
+
+    private function reflectExecuteMethod()
+    {
+        $r = new ReflectionMethod($this->command, 'execute');
+        $r->setAccessible(true);
+        return $r;
+    }
+
+    public function testConfigureSetsExpectedDescription()
+    {
+        $this->assertContains('Create a PSR-15 request handler', $this->command->getDescription());
+    }
+
+    public function testConfigureSetsExpectedHelp()
+    {
+        $this->assertEquals(CreateHandlerCommand::HELP, $this->command->getHelp());
+    }
+
+    public function testConfigureSetsExpectedArguments()
+    {
+        $definition = $this->command->getDefinition();
+        $this->assertTrue($definition->hasArgument('handler'));
+        $argument = $definition->getArgument('handler');
+        $this->assertTrue($argument->isRequired());
+        $this->assertEquals(CreateHandlerCommand::HELP_ARG_HANDLER, $argument->getDescription());
+    }
+
+    public function testSuccessfulExecutionEmitsExpectedMessages()
+    {
+        $generator = Mockery::mock('overload:' . CreateHandler::class);
+        $generator->shouldReceive('process')
+            ->once()
+            ->with('Foo\TestHandler')
+            ->andReturn(__DIR__);
+
+        $this->input->getArgument('handler')->willReturn('Foo\TestHandler');
+        $this->output
+            ->writeln(Argument::containingString('Creating request handler Foo\TestHandler'))
+            ->shouldBeCalled();
+        $this->output
+            ->writeln(Argument::containingString('Success'))
+            ->shouldBeCalled();
+        $this->output
+            ->writeln(Argument::containingString('Created class Foo\TestHandler, in file ' . __DIR__))
+            ->shouldBeCalled();
+
+        $method = $this->reflectExecuteMethod();
+
+        $this->assertSame(0, $method->invoke(
+            $this->command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+    }
+
+    public function testAllowsExceptionsRaisedFromCreateHandlerToBubbleUp()
+    {
+        $generator = Mockery::mock('overload:' . CreateHandler::class);
+        $generator->shouldReceive('process')
+            ->once()
+            ->with('Foo\TestHandler')
+            ->andThrow(CreateHandlerException::class, 'ERROR THROWN');
+
+        $this->input->getArgument('handler')->willReturn('Foo\TestHandler');
+        $this->output
+            ->writeln(Argument::containingString('Creating request handler Foo\TestHandler'))
+            ->shouldBeCalled();
+
+        $this->output
+            ->writeln(Argument::containingString('Success'))
+            ->shouldNotBeCalled();
+
+        $method = $this->reflectExecuteMethod();
+
+        $this->expectException(CreateHandlerException::class);
+        $this->expectExceptionMessage('ERROR THROWN');
+
+        $method->invoke(
+            $this->command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        );
+    }
+}

--- a/test/CreateHandler/CreateHandlerExceptionTest.php
+++ b/test/CreateHandler/CreateHandlerExceptionTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Tooling\CreateHandler;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Expressive\Tooling\CreateHandler\CreateHandlerException;
+
+class CreateHandlerExceptionTest extends TestCase
+{
+    public function testMissingComposerJsonReturnsInstance()
+    {
+        $e = CreateHandlerException::missingComposerJson();
+        $this->assertInstanceOf(CreateHandlerException::class, $e);
+        $this->assertContains('Could not find a composer.json', $e->getMessage());
+    }
+
+    public function testMissingComposerAutoloadersReturnsInstance()
+    {
+        $e = CreateHandlerException::missingComposerAutoloaders();
+        $this->assertInstanceOf(CreateHandlerException::class, $e);
+        $this->assertContains('PSR-4 autoloaders', $e->getMessage());
+    }
+
+    public function testInvalidComposerJsonReturnsInstanceWithErrorMessage()
+    {
+        $error = 'Invalid or malformed JSON';
+        $e = CreateHandlerException::invalidComposerJson($error);
+        $this->assertInstanceOf(CreateHandlerException::class, $e);
+        $this->assertContains('Unable to parse composer.json: ', $e->getMessage());
+        $this->assertContains($error, $e->getMessage());
+    }
+
+    public function testAutoloaderNotFoundReturnsInstanceUsingClassNameProvided()
+    {
+        $expected = __CLASS__;
+        $e = CreateHandlerException::autoloaderNotFound($expected);
+        $this->assertInstanceOf(CreateHandlerException::class, $e);
+        $this->assertContains('match ' . $expected, $e->getMessage());
+    }
+
+    public function testUnableToCreatePathReturnsInstanceUsingPathAndClassProvided()
+    {
+        $path = __FILE__;
+        $class = __CLASS__;
+        $e = CreateHandlerException::unableToCreatePath($path, $class);
+        $this->assertInstanceOf(CreateHandlerException::class, $e);
+        $this->assertContains('directory ' . $path, $e->getMessage());
+        $this->assertContains('class ' . $class, $e->getMessage());
+    }
+
+    public function testClassExistsReturnsInstanceUsingPathAndClassProvided()
+    {
+        $path = __FILE__;
+        $class = __CLASS__;
+        $e = CreateHandlerException::classExists($path, $class);
+        $this->assertInstanceOf(CreateHandlerException::class, $e);
+        $this->assertContains('directory ' . $path, $e->getMessage());
+        $this->assertContains('Class ' . $class, $e->getMessage());
+    }
+}

--- a/test/CreateHandler/CreateHandlerTest.php
+++ b/test/CreateHandler/CreateHandlerTest.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Tooling\CreateHandler;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\TestCase;
+use Zend\Expressive\Tooling\CreateHandler\CreateHandler;
+use Zend\Expressive\Tooling\CreateHandler\CreateHandlerException;
+
+class CreateHandlerTest extends TestCase
+{
+    /** @var vfsStreamDirectory */
+    private $dir;
+
+    /** @var string */
+    private $projectRoot;
+
+    public function setUp()
+    {
+        $this->dir = vfsStream::setup('project');
+        $this->projectRoot = vfsStream::url('project');
+    }
+
+    public function testProcessRaisesExceptionWhenComposerJsonNotPresentInProjectRoot()
+    {
+        $generator = new CreateHandler();
+
+        $this->expectException(CreateHandlerException::class);
+        $this->expectExceptionMessage('find a composer.json');
+
+        $generator->process('Foo\Bar\BazHandler', $this->projectRoot);
+    }
+
+    public function testProcessRaisesExceptionForMalformedComposerJson()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', 'not-a-value');
+        $generator = new CreateHandler();
+
+        $this->expectException(CreateHandlerException::class);
+        $this->expectExceptionMessage('Unable to parse');
+
+        $generator->process('Foo\Bar\BazHandler', $this->projectRoot);
+    }
+
+    public function testProcessRaisesExceptionIfComposerJsonDoesNotDefinePsr4Autoloaders()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode(['name' => 'some/project']));
+        $generator = new CreateHandler();
+
+        $this->expectException(CreateHandlerException::class);
+        $this->expectExceptionMessage('PSR-4 autoloaders');
+
+        $generator->process('Foo\Bar\BazHandler', $this->projectRoot);
+    }
+
+    public function testProcessRaisesExceptionIfComposerJsonDefinesMalformedPsr4Autoloaders()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => 'not-valid',
+            ],
+        ]));
+        $generator = new CreateHandler();
+
+        $this->expectException(CreateHandlerException::class);
+        $this->expectExceptionMessage('PSR-4 autoloaders');
+
+        $generator->process('Foo\Bar\BazHandler', $this->projectRoot);
+    }
+
+    public function testProcessRaisesExceptionIfClassDoesNotMatchAnyAutoloadableNamespaces()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/App/',
+                ],
+            ],
+        ]));
+        $generator = new CreateHandler();
+
+        $this->expectException(CreateHandlerException::class);
+        $this->expectExceptionMessage('Unable to match');
+
+        $generator->process('Foo\Bar\BazHandler', $this->projectRoot);
+    }
+
+    public function testProcessRaisesExceptionIfUnableToCreateSubPath()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/App/',
+                    'Foo\\' => 'src/Foo/src/',
+                ],
+            ],
+        ]));
+        vfsStream::newDirectory('src/Foo/src', 0555)->at($this->dir);
+
+        $generator = new CreateHandler();
+
+        $this->expectException(CreateHandlerException::class);
+        $this->expectExceptionMessage('Unable to create the directory');
+
+        $generator->process('Foo\Bar\BazHandler', $this->projectRoot);
+    }
+
+    public function testProcessCanCreateHandlerInNamespaceRoot()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/App/',
+                    'Foo\\' => 'src/Foo/',
+                ],
+            ],
+        ]));
+        vfsStream::newDirectory('src/Foo/src', 0775)->at($this->dir);
+
+        $generator = new CreateHandler();
+
+        $expectedPath = vfsStream::url('project/src/Foo/BarHandler.php');
+        $this->assertEquals(
+            $expectedPath,
+            $generator->process('Foo\BarHandler', $this->projectRoot)
+        );
+
+        $classFileContents = file_get_contents($expectedPath);
+        $this->assertRegexp('#^\<\?php#s', $classFileContents);
+        $this->assertRegexp('#^namespace Foo;$#m', $classFileContents);
+        $this->assertRegexp('#^class BarHandler implements RequestHandlerInterface$#m', $classFileContents);
+        $this->assertRegexp(
+            '#^\s{4}public function handle\(ServerRequestInterface \$request\) : ResponseInterface$#m',
+            $classFileContents
+        );
+    }
+
+    public function testProcessCanCreateHandlerInSubNamespacePath()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/App/',
+                    'Foo\\' => 'src/Foo/',
+                ],
+            ],
+        ]));
+        vfsStream::newDirectory('src/Foo/src', 0775)->at($this->dir);
+
+        $generator = new CreateHandler();
+
+        $expectedPath = vfsStream::url('project/src/Foo/Bar/BazHandler.php');
+        $this->assertEquals(
+            $expectedPath,
+            $generator->process('Foo\Bar\BazHandler', $this->projectRoot)
+        );
+
+        $classFileContents = file_get_contents($expectedPath);
+        $this->assertRegexp('#^\<\?php#s', $classFileContents);
+        $this->assertRegexp('#^namespace Foo\\\\Bar;$#m', $classFileContents);
+        $this->assertRegexp('#^class BazHandler implements RequestHandlerInterface$#m', $classFileContents);
+        $this->assertRegexp(
+            '#^\s{4}public function handle\(ServerRequestInterface \$request\) : ResponseInterface$#m',
+            $classFileContents
+        );
+    }
+
+    public function testProcessCanCreateHandlerInModuleNamespaceRoot()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/App/',
+                    'Foo\\' => 'src/Foo/src/',
+                ],
+            ],
+        ]));
+        vfsStream::newDirectory('src/Foo/src', 0775)->at($this->dir);
+
+        $generator = new CreateHandler();
+
+        $expectedPath = vfsStream::url('project/src/Foo/src/BarHandler.php');
+        $this->assertEquals(
+            $expectedPath,
+            $generator->process('Foo\BarHandler', $this->projectRoot)
+        );
+
+        $classFileContents = file_get_contents($expectedPath);
+        $this->assertRegexp('#^\<\?php#s', $classFileContents);
+        $this->assertRegexp('#^namespace Foo;$#m', $classFileContents);
+        $this->assertRegexp('#^class BarHandler implements RequestHandlerInterface$#m', $classFileContents);
+        $this->assertRegexp(
+            '#^\s{4}public function handle\(ServerRequestInterface \$request\) : ResponseInterface$#m',
+            $classFileContents
+        );
+    }
+
+    public function testProcessCanCreateHandlerInModuleSubNamespacePath()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/App/',
+                    'Foo\\' => 'src/Foo/src/',
+                ],
+            ],
+        ]));
+        vfsStream::newDirectory('src/Foo/src', 0775)->at($this->dir);
+
+        $generator = new CreateHandler();
+
+        $expectedPath = vfsStream::url('project/src/Foo/src/Bar/BazHandler.php');
+        $this->assertEquals(
+            $expectedPath,
+            $generator->process('Foo\Bar\BazHandler', $this->projectRoot)
+        );
+
+        $classFileContents = file_get_contents($expectedPath);
+        $this->assertRegexp('#^\<\?php#s', $classFileContents);
+        $this->assertRegexp('#^namespace Foo\\\\Bar;$#m', $classFileContents);
+        $this->assertRegexp('#^class BazHandler implements RequestHandlerInterface$#m', $classFileContents);
+        $this->assertRegexp(
+            '#^\s{4}public function handle\(ServerRequestInterface \$request\) : ResponseInterface$#m',
+            $classFileContents
+        );
+    }
+
+    public function testProcessThrowsExceptionIfClassAlreadyExists()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/App/',
+                ],
+            ],
+        ]));
+
+        vfsStream::newDirectory('src/App/Foo', 0775)->at($this->dir);
+        file_put_contents($this->projectRoot . '/src/App/Foo/BarHandler.php', 'App\Foo\BarHandler');
+
+        $generator = new CreateHandler();
+
+        $this->expectException(CreateHandlerException::class);
+        $this->expectExceptionMessage('Class BarHandler already exists');
+
+        $generator->process('App\Foo\BarHandler', $this->projectRoot);
+    }
+
+    public function testTheClassSkeletonParameterOverridesTheConstant()
+    {
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/App/',
+                    'Foo\\' => 'src/Foo/',
+                ],
+            ],
+        ]));
+        vfsStream::newDirectory('src/Foo/src', 0775)->at($this->dir);
+
+        $generator = new CreateHandler();
+
+        $expectedPath = vfsStream::url('project/src/Foo/Bar/BazHandler.php');
+        $this->assertEquals(
+            $expectedPath,
+            $generator->process('Foo\Bar\BazHandler', $this->projectRoot, 'class Foo\Bar\BazHandler')
+        );
+
+        $classFileContents = file_get_contents($expectedPath);
+        $this->assertContains('class Foo\Bar\BazHandler', $classFileContents);
+    }
+}

--- a/test/CreateMiddleware/CreateMiddlewareCommandTest.php
+++ b/test/CreateMiddleware/CreateMiddlewareCommandTest.php
@@ -45,7 +45,7 @@ class CreateMiddlewareCommandTest extends TestCase
 
     public function testConfigureSetsExpectedDescription()
     {
-        $this->assertContains('Create an http-interop middleware', $this->command->getDescription());
+        $this->assertContains('Create a PSR-15 middleware', $this->command->getDescription());
     }
 
     public function testConfigureSetsExpectedHelp()


### PR DESCRIPTION
This new command will create a PSR-15 request handler class named after the argument provided to it, and placed in the filesystem based on the namespace and configured autoloaders. It is a sibling to `middleware:create`.