### PR TITLE
Ensure generated template config is correct

### DIFF
--- a/src/Module/Create.php
+++ b/src/Module/Create.php
@@ -65,9 +65,7 @@ class ConfigProvider
     {
         return [
             'paths' => [
-                'app'    => [__DIR__ . '/../templates/app'],
-                'error'  => [__DIR__ . '/../templates/error'],
-                'layout' => [__DIR__ . '/../templates/layout'],
+                '%2$s'    => [__DIR__ . '/../templates/'],
             ],
         ];
     }
@@ -124,10 +122,11 @@ EOT;
             ));
         }
 
-        if (! mkdir($modulePath . '/templates')) {
+        $templatePath = sprintf('%s/templates', $modulePath);
+        if (! mkdir($templatePath)) {
             throw new Exception\RuntimeException(sprintf(
-                'Module templates directory "%s/templates" cannot be created',
-                $modulePath
+                'Module templates directory "%s" cannot be created',
+                $templatePath
             ));
         }
     }
@@ -145,8 +144,20 @@ EOT;
             sprintf('%s/src/ConfigProvider.php', $modulePath),
             sprintf(
                 self::TEMPLATE_CONFIG_PROVIDER,
-                $moduleName
+                $moduleName,
+                $this->createTemplateNamespace($moduleName)
             )
         );
+    }
+
+    /**
+     * @param string $moduleName
+     * @return string
+     */
+    private function createTemplateNamespace($moduleName)
+    {
+        $namespace = str_replace('\\', '-', $moduleName);
+        $namespace = strtolower($namespace);
+        return $namespace;
     }
 }

--- a/test/Module/CreateTest.php
+++ b/test/Module/CreateTest.php
@@ -132,7 +132,7 @@ class CreateTest extends TestCase
         $this->assertSame(1, preg_match('/\bnamespace MyApp\b/', $configProviderContent));
         $this->assertSame(1, preg_match('/\bclass ConfigProvider\b/', $configProviderContent));
         $command = $this->command;
-        $expectedContent = sprintf($command::TEMPLATE_CONFIG_PROVIDER, 'MyApp');
+        $expectedContent = sprintf($command::TEMPLATE_CONFIG_PROVIDER, 'MyApp', 'myapp');
         $this->assertSame($expectedContent, $configProviderContent);
     }
 }


### PR DESCRIPTION
This patch ensures that the template configuration generated for a new module is correct. In particular:

- It no longer creates "layout" and "error" keys, as these will generally be governed by the `App` module itself.
- It creates a template namespace based on the module namespace (converting `\\` to `-`, and lowercasing), and assigns it to the module's "templates/" directory.

Fixes #43.