### PR TITLE
PHP 7.2 consistency changes

### DIFF
--- a/src/CreateHandler/CreateHandler.php
+++ b/src/CreateHandler/CreateHandler.php
@@ -19,7 +19,7 @@ class CreateHandler
     /**
      * @var string Template for request handler class.
      */
-    const CLASS_SKELETON = <<< 'EOS'
+    public const CLASS_SKELETON = <<< 'EOS'
 <?php
 
 namespace %namespace%;
@@ -41,14 +41,13 @@ class %class% implements RequestHandlerInterface
 EOS;
 
     /**
-     * @param string $class
-     * @param string|null $projectRoot
-     * @param string $classSkeleton
-     * @return string
      * @throws CreateHandlerException
      */
-    public function process($class, $projectRoot = null, $classSkeleton = self::CLASS_SKELETON)
-    {
+    public function process(
+        string $class,
+        string $projectRoot = null,
+        string $classSkeleton = self::CLASS_SKELETON
+    ) : string {
         $projectRoot = $projectRoot ?: getcwd();
 
         $path = $this->getClassPath($class, $projectRoot);
@@ -70,12 +69,9 @@ EOS;
     }
 
     /**
-     * @param string $class
-     * @param string $projectRoot
-     * @return string
      * @throws CreateHandlerException
      */
-    private function getClassPath($class, $projectRoot)
+    private function getClassPath(string $class, string $projectRoot) : string
     {
         $autoloaders = $this->getComposerAutoloaders($projectRoot);
         list($namespace, $path) = $this->discoverNamespaceAndPath($class, $autoloaders);
@@ -106,11 +102,10 @@ EOS;
     }
 
     /**
-     * @param string $projectRoot
      * @return array Associative array of namespace/path pairs
      * @throws CreateHandlerException
      */
-    private function getComposerAutoloaders($projectRoot)
+    private function getComposerAutoloaders(string $projectRoot) : array
     {
         $composerPath = sprintf('%s/composer.json', $projectRoot);
         if (! file_exists($composerPath)) {
@@ -135,12 +130,10 @@ EOS;
     }
 
     /**
-     * @param string $class
-     * @param array $autoloaders
      * @return array [namespace, path]
      * @throws CreateHandlerException
      */
-    private function discoverNamespaceAndPath($class, array $autoloaders)
+    private function discoverNamespaceAndPath(string $class, array $autoloaders) : array
     {
         foreach ($autoloaders as $namespace => $path) {
             if (0 === strpos($class, $namespace)) {
@@ -160,10 +153,9 @@ EOS;
     }
 
     /**
-     * @param string $class
      * @return array [namespace, class]
      */
-    private function getNamespaceAndClass($class)
+    private function getNamespaceAndClass(string $class) : array
     {
         $parts = explode('\\', $class);
         $className = array_pop($parts);

--- a/src/CreateHandler/CreateHandlerCommand.php
+++ b/src/CreateHandler/CreateHandlerCommand.php
@@ -16,15 +16,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CreateHandlerCommand extends Command
 {
-    const DEFAULT_SRC = '/src';
+    public const DEFAULT_SRC = '/src';
 
-    const HELP = <<< 'EOT'
+    public const HELP = <<< 'EOT'
 Creates a PSR-15 request handler class file named after the provided
 class. For a path, it matches the class namespace against PSR-4 autoloader
 namespaces in your composer.json.
 EOT;
 
-    const HELP_ARG_HANDLER = <<< 'EOT'
+    public const HELP_ARG_HANDLER = <<< 'EOT'
 Fully qualified class name of the request handler to create. This value
 should be quoted to ensure namespace separators are not interpreted as
 escape sequences by your shell.
@@ -33,7 +33,7 @@ EOT;
     /**
      * Configure the console command.
      */
-    protected function configure()
+    protected function configure() : void
     {
         $this->setDescription('Create a PSR-15 request handler class file.');
         $this->setHelp(self::HELP);
@@ -43,11 +43,9 @@ EOT;
     /**
      * Execute console command.
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
      * @return int Exit status
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output) : int
     {
         $handler = $input->getArgument('handler');
 

--- a/src/CreateHandler/CreateHandlerException.php
+++ b/src/CreateHandler/CreateHandlerException.php
@@ -13,19 +13,15 @@ use RuntimeException;
 
 class CreateHandlerException extends RuntimeException
 {
-    /**
-     * @return self
-     */
-    public static function missingComposerJson()
+    public static function missingComposerJson() : self
     {
         return new self('Could not find a composer.json in the project root');
     }
 
     /**
      * @param string $error Error string related to JSON_ERROR_* constant
-     * @return self
      */
-    public static function invalidComposerJson($error)
+    public static function invalidComposerJson(string $error) : self
     {
         return new self(sprintf(
             'Unable to parse composer.json: %s',
@@ -33,19 +29,12 @@ class CreateHandlerException extends RuntimeException
         ));
     }
 
-    /**
-     * @return self
-     */
-    public static function missingComposerAutoloaders()
+    public static function missingComposerAutoloaders() : self
     {
         return new self('composer.json does not define any PSR-4 autoloaders');
     }
 
-    /**
-     * @param string $class
-     * @return self
-     */
-    public static function autoloaderNotFound($class)
+    public static function autoloaderNotFound(string $class) : self
     {
         return new self(sprintf(
             'Unable to match %s to an autoloadable PSR-4 namespace',
@@ -53,12 +42,7 @@ class CreateHandlerException extends RuntimeException
         ));
     }
 
-    /**
-     * @param string $path
-     * @param string $class
-     * @return self
-     */
-    public static function unableToCreatePath($path, $class)
+    public static function unableToCreatePath(string $path, string $class) : self
     {
         return new self(sprintf(
             'Unable to create the directory %s for creating the class %s',
@@ -67,12 +51,7 @@ class CreateHandlerException extends RuntimeException
         ));
     }
 
-    /**
-     * @param string $path
-     * @param string $class
-     * @return self
-     */
-    public static function classExists($path, $class)
+    public static function classExists(string $path, string $class) : self
     {
         return new self(sprintf(
             'Class %s already exists in directory %s',

--- a/src/CreateMiddleware/CreateMiddleware.php
+++ b/src/CreateMiddleware/CreateMiddleware.php
@@ -19,7 +19,7 @@ class CreateMiddleware
     /**
      * @var string Template for middleware class.
      */
-    const CLASS_SKELETON = <<< 'EOS'
+    public const CLASS_SKELETON = <<< 'EOS'
 <?php
 
 namespace %namespace%;
@@ -42,14 +42,13 @@ class %class% implements MiddlewareInterface
 EOS;
 
     /**
-     * @param string $class
-     * @param string|null $projectRoot
-     * @param string $classSkeleton
-     * @return string
      * @throws CreateMiddlewareException
      */
-    public function process($class, $projectRoot = null, $classSkeleton = self::CLASS_SKELETON)
-    {
+    public function process(
+        string $class,
+        string $projectRoot = null,
+        string $classSkeleton = self::CLASS_SKELETON
+    ) : string {
         $projectRoot = $projectRoot ?: getcwd();
 
         $path = $this->getClassPath($class, $projectRoot);
@@ -71,12 +70,9 @@ EOS;
     }
 
     /**
-     * @param string $class
-     * @param string $projectRoot
-     * @return string
      * @throws CreateMiddlewareException
      */
-    private function getClassPath($class, $projectRoot)
+    private function getClassPath(string $class, string $projectRoot) : string
     {
         $autoloaders = $this->getComposerAutoloaders($projectRoot);
         list($namespace, $path) = $this->discoverNamespaceAndPath($class, $autoloaders);
@@ -107,11 +103,10 @@ EOS;
     }
 
     /**
-     * @param string $projectRoot
      * @return array Associative array of namespace/path pairs
      * @throws CreateMiddlewareException
      */
-    private function getComposerAutoloaders($projectRoot)
+    private function getComposerAutoloaders(string $projectRoot) : array
     {
         $composerPath = sprintf('%s/composer.json', $projectRoot);
         if (! file_exists($composerPath)) {
@@ -136,12 +131,10 @@ EOS;
     }
 
     /**
-     * @param string $class
-     * @param array $autoloaders
      * @return array [namespace, path]
      * @throws CreateMiddlewareException
      */
-    private function discoverNamespaceAndPath($class, array $autoloaders)
+    private function discoverNamespaceAndPath(string $class, array $autoloaders) : array
     {
         foreach ($autoloaders as $namespace => $path) {
             if (0 === strpos($class, $namespace)) {
@@ -161,10 +154,9 @@ EOS;
     }
 
     /**
-     * @param string $class
      * @return array [namespace, class]
      */
-    private function getNamespaceAndClass($class)
+    private function getNamespaceAndClass(string $class) : array
     {
         $parts = explode('\\', $class);
         $className = array_pop($parts);

--- a/src/CreateMiddleware/CreateMiddlewareCommand.php
+++ b/src/CreateMiddleware/CreateMiddlewareCommand.php
@@ -16,15 +16,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CreateMiddlewareCommand extends Command
 {
-    const DEFAULT_SRC = '/src';
+    public const DEFAULT_SRC = '/src';
 
-    const HELP = <<< 'EOT'
+    public const HELP = <<< 'EOT'
 Creates a PSR-15 middleware class file named after the provided class. For a
 path, it matches the class namespace against PSR-4 autoloader namespaces in
 your composer.json.
 EOT;
 
-    const HELP_ARG_MIDDLEWARE = <<< 'EOT'
+    public const HELP_ARG_MIDDLEWARE = <<< 'EOT'
 Fully qualified class name of the middleware to create. This value
 should be quoted to ensure namespace separators are not interpreted as
 escape sequences by your shell.
@@ -33,7 +33,7 @@ EOT;
     /**
      * Configure the console command.
      */
-    protected function configure()
+    protected function configure() : void
     {
         $this->setDescription('Create a PSR-15 middleware class file.');
         $this->setHelp(self::HELP);
@@ -43,11 +43,9 @@ EOT;
     /**
      * Execute console command.
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
      * @return int Exit status
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output) : int
     {
         $middleware = $input->getArgument('middleware');
 

--- a/src/CreateMiddleware/CreateMiddlewareException.php
+++ b/src/CreateMiddleware/CreateMiddlewareException.php
@@ -13,19 +13,15 @@ use RuntimeException;
 
 class CreateMiddlewareException extends RuntimeException
 {
-    /**
-     * @return self
-     */
-    public static function missingComposerJson()
+    public static function missingComposerJson() : self
     {
         return new self('Could not find a composer.json in the project root');
     }
 
     /**
      * @param string $error Error string related to JSON_ERROR_* constant
-     * @return self
      */
-    public static function invalidComposerJson($error)
+    public static function invalidComposerJson(string $error) : self
     {
         return new self(sprintf(
             'Unable to parse composer.json: %s',
@@ -33,19 +29,12 @@ class CreateMiddlewareException extends RuntimeException
         ));
     }
 
-    /**
-     * @return self
-     */
-    public static function missingComposerAutoloaders()
+    public static function missingComposerAutoloaders() : self
     {
         return new self('composer.json does not define any PSR-4 autoloaders');
     }
 
-    /**
-     * @param string $class
-     * @return self
-     */
-    public static function autoloaderNotFound($class)
+    public static function autoloaderNotFound(string $class) : self
     {
         return new self(sprintf(
             'Unable to match %s to an autoloadable PSR-4 namespace',
@@ -53,12 +42,7 @@ class CreateMiddlewareException extends RuntimeException
         ));
     }
 
-    /**
-     * @param string $path
-     * @param string $class
-     * @return self
-     */
-    public static function unableToCreatePath($path, $class)
+    public static function unableToCreatePath(string $path, string $class) : self
     {
         return new self(sprintf(
             'Unable to create the directory %s for creating the class %s',
@@ -67,12 +51,7 @@ class CreateMiddlewareException extends RuntimeException
         ));
     }
 
-    /**
-     * @param string $path
-     * @param string $class
-     * @return self
-     */
-    public static function classExists($path, $class)
+    public static function classExists(string $path, string $class) : self
     {
         return new self(sprintf(
             'Class %s already exists in directory %s',

--- a/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
+++ b/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
@@ -23,7 +23,7 @@ class ConvertInteropMiddleware
         $this->output = $output;
     }
 
-    public function process(string $directory)
+    public function process(string $directory) : void
     {
         $rdi = new RecursiveDirectoryIterator($directory);
         $rii = new RecursiveIteratorIterator($rdi);

--- a/src/MigrateInteropMiddleware/MigrateInteropMiddlewareCommand.php
+++ b/src/MigrateInteropMiddleware/MigrateInteropMiddlewareCommand.php
@@ -39,7 +39,7 @@ EOT;
     /**
      * @var null|string Project root against which to scan.
      */
-    public function setProjectDir($path)
+    public function setProjectDir(?string $path) : void
     {
         $this->projectDir = $path;
     }
@@ -48,22 +48,20 @@ EOT;
      * Retrieve the project root directory.
      *
      * Uses result of getcwd() if not previously set.
-     *
-     * @return string
      */
-    private function getProjectDir()
+    private function getProjectDir() : string
     {
         return $this->projectDir ?: getcwd();
     }
 
-    protected function configure()
+    protected function configure() : void
     {
         $this->setDescription('Migrate interop middlewares and delegators');
         $this->setHelp(self::HELP);
         $this->addOption('src', 's', InputOption::VALUE_REQUIRED, self::HELP_OPT_SRC);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output) : int
     {
         $src = $this->getSrcDir($input);
 
@@ -72,23 +70,15 @@ EOT;
         $converter = new ConvertInteropMiddleware($output);
         $converter->process($src);
 
-//        if ($converter->originalResponseFound()) {
-//            $output->writeln('<error>One or more files contained calls to getOriginalResponse().</error>');
-//            $output->writeln('<info>Check the above logs to determine which files need attention.</info>');
-//            $output->writeln(self::TEMPLATE_RESPONSE_DETAILS);
-//        }
-
         $output->writeln('<info>Done!</info>');
 
         return 0;
     }
 
     /**
-     * @param InputInterface $input
-     * @return string
      * @throws ArgvException
      */
-    private function getSrcDir(InputInterface $input)
+    private function getSrcDir(InputInterface $input) : string
     {
         $path = $input->getOption('src') ?: self::DEFAULT_SRC;
         $path = $this->getProjectDir() . '/' . $path;

--- a/src/Module/CommandCommonOptions.php
+++ b/src/Module/CommandCommonOptions.php
@@ -24,7 +24,7 @@ final class CommandCommonOptions
      *
      * @param Command $command
      */
-    public static function addDefaultOptionsAndArguments(Command $command)
+    public static function addDefaultOptionsAndArguments(Command $command) : void
     {
         $command->addArgument(
             'module',
@@ -49,11 +49,8 @@ final class CommandCommonOptions
 
     /**
      * Retrieve the modules path from input
-     *
-     * @param InputInterface $input
-     * @return string
      */
-    public static function getModulesPath(InputInterface $input)
+    public static function getModulesPath(InputInterface $input) : string
     {
         $modulesPath = $input->getOption('modules-path') ?: 'src';
         $modulesPath = preg_replace('/^\.\//', '', str_replace('\\', '/', $modulesPath));

--- a/src/Module/Create.php
+++ b/src/Module/Create.php
@@ -13,7 +13,7 @@ use Zend\Expressive\Tooling\Module\Exception;
 
 class Create
 {
-    const TEMPLATE_CONFIG_PROVIDER = <<< 'EOT'
+    public const TEMPLATE_CONFIG_PROVIDER = <<< 'EOT'
 <?php
 
 namespace %1$s;
@@ -30,10 +30,8 @@ class ConfigProvider
      *
      * To add a bit of a structure, each section is defined in a separate
      * method which returns an array with its configuration.
-     *
-     * @return array
      */
-    public function __invoke()
+    public function __invoke() : array
     {
         return [
             'dependencies' => $this->getDependencies(),
@@ -43,10 +41,8 @@ class ConfigProvider
 
     /**
      * Returns the container dependencies
-     *
-     * @return array
      */
-    public function getDependencies()
+    public function getDependencies() : array
     {
         return [
             'invokables' => [
@@ -58,10 +54,8 @@ class ConfigProvider
 
     /**
      * Returns the templates configuration
-     *
-     * @return array
      */
-    public function getTemplates()
+    public function getTemplates() : array
     {
         return [
             'paths' => [
@@ -75,13 +69,8 @@ EOT;
 
     /**
      * Create source tree for the expressive module.
-     *
-     * @param string $moduleName
-     * @param string $modulesPath
-     * @param string $projectDir
-     * @return string
      */
-    public function process($moduleName, $modulesPath, $projectDir)
+    public function process(string $moduleName, string $modulesPath, string $projectDir) : string
     {
         $modulePath = sprintf('%s/%s/%s', $projectDir, $modulesPath, $moduleName);
 
@@ -94,29 +83,26 @@ EOT;
     /**
      * Creates directory structure for new expressive module.
      *
-     * @param string $modulePath
-     * @param string $moduleName
-     * @return void
-     * @throws Exception\RuntimeException
+     * @throws RuntimeException
      */
-    private function createDirectoryStructure($modulePath, $moduleName)
+    private function createDirectoryStructure(string $modulePath, string $moduleName) : void
     {
         if (file_exists($modulePath)) {
-            throw new Exception\RuntimeException(sprintf(
+            throw new RuntimeException(sprintf(
                 'Module "%s" already exists',
                 $moduleName
             ));
         }
 
         if (! mkdir($modulePath)) {
-            throw new Exception\RuntimeException(sprintf(
+            throw new RuntimeException(sprintf(
                 'Module directory "%s" cannot be created',
                 $modulePath
             ));
         }
 
         if (! mkdir($modulePath . '/src')) {
-            throw new Exception\RuntimeException(sprintf(
+            throw new RuntimeException(sprintf(
                 'Module source directory "%s/src" cannot be created',
                 $modulePath
             ));
@@ -124,7 +110,7 @@ EOT;
 
         $templatePath = sprintf('%s/templates', $modulePath);
         if (! mkdir($templatePath)) {
-            throw new Exception\RuntimeException(sprintf(
+            throw new RuntimeException(sprintf(
                 'Module templates directory "%s" cannot be created',
                 $templatePath
             ));
@@ -133,12 +119,8 @@ EOT;
 
     /**
      * Creates ConfigProvider for new expressive module.
-     *
-     * @param string $modulePath
-     * @param string $moduleName
-     * @return void
      */
-    private function createConfigProvider($modulePath, $moduleName)
+    private function createConfigProvider(string $modulePath, string $moduleName) : void
     {
         file_put_contents(
             sprintf('%s/src/ConfigProvider.php', $modulePath),
@@ -150,11 +132,7 @@ EOT;
         );
     }
 
-    /**
-     * @param string $moduleName
-     * @return string
-     */
-    private function createTemplateNamespace($moduleName)
+    private function createTemplateNamespace(string $moduleName) : string
     {
         $namespace = str_replace('\\', '-', $moduleName);
         $namespace = strtolower($namespace);

--- a/src/Module/CreateCommand.php
+++ b/src/Module/CreateCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CreateCommand extends Command
 {
-    const HELP = <<< 'EOT'
+    public const HELP = <<< 'EOT'
 Create a new middleware module for the application.
 
 - Creates an appropriate module structure containing a source code tree,
@@ -27,12 +27,12 @@ Create a new middleware module for the application.
   configuration.
 EOT;
 
-    const HELP_ARG_MODULE = 'The module to create and register with the application.';
+    public const HELP_ARG_MODULE = 'The module to create and register with the application.';
 
     /**
      * Configure command.
      */
-    protected function configure()
+    protected function configure() : void
     {
         $this->setDescription('Create and register a middleware module with the application');
         $this->setHelp(self::HELP);
@@ -47,7 +47,7 @@ EOT;
      *
      * {@inheritDoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output) : int
     {
         $module = $input->getArgument('module');
         $composer = $input->getOption('composer') ?: 'composer';
@@ -71,10 +71,8 @@ EOT;
      * Retrieve the name of the "register" command.
      *
      * Varies with usage of the "expressive" vs "expressive-module" command.
-     *
-     * @return string
      */
-    private function getRegisterCommandName()
+    private function getRegisterCommandName() : string
     {
         return 0 === strpos($this->getName(), 'module:')
             ? 'module:register'

--- a/src/Module/DeregisterCommand.php
+++ b/src/Module/DeregisterCommand.php
@@ -17,7 +17,7 @@ use ZF\ComposerAutoloading\Command\Disable;
 
 class DeregisterCommand extends Command
 {
-    const HELP = <<< 'EOT'
+    public const HELP = <<< 'EOT'
 Deregister an existing middleware module from the application, by:
 
 - Removing the associated PSR-4 autoloader entry from composer.json, and
@@ -26,12 +26,12 @@ Deregister an existing middleware module from the application, by:
   application configuration.
 EOT;
 
-    const HELP_ARG_MODULE = 'The module to register with the application';
+    public const HELP_ARG_MODULE = 'The module to register with the application';
 
     /**
      * Configure command.
      */
-    protected function configure()
+    protected function configure() : void
     {
         $this->setDescription('Deregister a middleware module from the application');
         $this->setHelp(self::HELP);
@@ -43,7 +43,7 @@ EOT;
      *
      * {@inheritDoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output) : int
     {
         $module = $input->getArgument('module');
         $composer = $input->getOption('composer') ?: 'composer';

--- a/src/Module/RegisterCommand.php
+++ b/src/Module/RegisterCommand.php
@@ -18,7 +18,7 @@ use ZF\ComposerAutoloading\Command\Enable;
 
 class RegisterCommand extends Command
 {
-    const HELP = <<< 'EOT'
+    public const HELP = <<< 'EOT'
 Register an existing middleware module with the application, by:
 
 - Ensuring a PSR-4 autoloader entry is present in composer.json, and the
@@ -27,24 +27,19 @@ Register an existing middleware module with the application, by:
   application configuration.
 EOT;
 
-    const HELP_ARG_MODULE = 'The module to register with the application';
+    public const HELP_ARG_MODULE = 'The module to register with the application';
 
     /**
      * Configure command.
      */
-    protected function configure()
+    protected function configure() : void
     {
         $this->setDescription('Register a middleware module with the application');
         $this->setHelp(self::HELP);
         CommandCommonOptions::addDefaultOptionsAndArguments($this);
     }
 
-    /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output) : int
     {
         $module = $input->getArgument('module');
         $composer = $input->getOption('composer') ?: 'composer';

--- a/src/Module/RuntimeException.php
+++ b/src/Module/RuntimeException.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Tooling\Module\Exception;
+namespace Zend\Expressive\Tooling\Module;
 
 class RuntimeException extends \RuntimeException
 {

--- a/test/Module/CreateCommandTest.php
+++ b/test/Module/CreateCommandTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Zend\Expressive\Tooling\Module\Create;
 use Zend\Expressive\Tooling\Module\CreateCommand;
-use Zend\Expressive\Tooling\Module\Exception\RuntimeException;
+use Zend\Expressive\Tooling\Module\RuntimeException;
 
 /**
  * @runTestsInSeparateProcesses

--- a/test/Module/CreateTest.php
+++ b/test/Module/CreateTest.php
@@ -14,7 +14,7 @@ use org\bovigo\vfs\vfsStreamDirectory;
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
 use Zend\Expressive\Tooling\Module\Create;
-use Zend\Expressive\Tooling\Module\Exception;
+use Zend\Expressive\Tooling\Module\RuntimeException;
 
 class CreateTest extends TestCase
 {
@@ -52,7 +52,7 @@ class CreateTest extends TestCase
     {
         vfsStream::newDirectory('MyApp')->at($this->modulesDir);
 
-        $this->expectException(Exception\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Module "MyApp" already exists');
         $this->command->process('MyApp', $this->modulesPath, $this->projectDir);
     }
@@ -66,7 +66,7 @@ class CreateTest extends TestCase
             ->with($baseModulePath)
             ->willReturn(false);
 
-        $this->expectException(Exception\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf(
             'Module directory "%s" cannot be created',
             $baseModulePath
@@ -87,7 +87,7 @@ class CreateTest extends TestCase
             ->with(sprintf('%s/src', $baseModulePath))
             ->willReturn(false);
 
-        $this->expectException(Exception\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf(
             'Module source directory "%s/src" cannot be created',
             $baseModulePath
@@ -112,7 +112,7 @@ class CreateTest extends TestCase
             ->with(sprintf('%s/templates', $baseModulePath))
             ->willReturn(false);
 
-        $this->expectException(Exception\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf(
             'Module templates directory "%s/templates" cannot be created',
             $baseModulePath


### PR DESCRIPTION
This patch does the following:

- Ensures all class constants have visibility declared.
- Adds scalar type hints to arguments wherever possible.
- Adds return type hints wherever possible.
- Renames `Zend\Expressive\Tooling\Module\Exception\RuntimeException` to `Zend\Expressive\Tooling\Module\RuntimeException`; all other commands declare exceptions at the same level as the command and/or utility classes.