### PR TITLE
Creates the `action:create` command

### DIFF
--- a/bin/expressive
+++ b/bin/expressive
@@ -31,6 +31,7 @@ if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
 $application = new Application('expressive', VERSION);
 $application->addCommands([
     new Factory\CreateFactoryCommand('factory:create'),
+    new CreateHandler\CreateHandlerCommand('action:create'),
     new CreateHandler\CreateHandlerCommand('handler:create'),
     new CreateMiddleware\CreateMiddlewareCommand('middleware:create'),
     new MigrateInteropMiddleware\MigrateInteropMiddlewareCommand('migrate:interop-middleware'),

--- a/src/CreateHandler/CreateHandlerCommand.php
+++ b/src/CreateHandler/CreateHandlerCommand.php
@@ -59,9 +59,13 @@ EOT;
      */
     protected function configure() : void
     {
+        $this->handlerArgument = (bool) preg_match('/^action:/', $this->getName())
+            ? 'action'
+            : 'handler'; // default argument
+
         $this->setDescription('Create a PSR-15 request handler class file.');
         $this->setHelp(self::HELP);
-        $this->addArgument('handler', InputArgument::REQUIRED, self::HELP_ARG_HANDLER);
+        $this->addArgument($this->handlerArgument, InputArgument::REQUIRED, self::HELP_ARG_HANDLER);
         $this->addOption('no-factory', null, InputOption::VALUE_NONE, self::HELP_OPT_NO_FACTORY);
         $this->addOption('no-register', null, InputOption::VALUE_NONE, self::HELP_OPT_NO_REGISTER);
     }
@@ -73,7 +77,7 @@ EOT;
      */
     protected function execute(InputInterface $input, OutputInterface $output) : int
     {
-        $handler = $input->getArgument('handler');
+        $handler = $input->getArgument($this->handlerArgument);
 
         $output->writeln(sprintf('<info>Creating request handler %s...</info>', $handler));
 

--- a/src/CreateHandler/CreateHandlerCommand.php
+++ b/src/CreateHandler/CreateHandlerCommand.php
@@ -20,29 +20,68 @@ class CreateHandlerCommand extends Command
 {
     public const DEFAULT_SRC = '/src';
 
-    public const HELP = <<< 'EOT'
+    public const HELP_HANDLER_DESCRIPTION = 'Create a PSR-15 request handler class file.';
+
+    public const HELP_HANDLER = <<< 'EOT'
 Creates a PSR-15 request handler class file named after the provided
 class. For a path, it matches the class namespace against PSR-4 autoloader
 namespaces in your composer.json.
 EOT;
 
-    public const HELP_ARG_HANDLER = <<< 'EOT'
+    public const HELP_HANDLER_ARG_HANDLER = <<< 'EOT'
 Fully qualified class name of the request handler to create. This value
 should be quoted to ensure namespace separators are not interpreted as
 escape sequences by your shell.
 EOT;
 
-    const HELP_OPT_NO_FACTORY = <<< 'EOT'
+    const HELP_HANDLER_OPT_NO_FACTORY = <<< 'EOT'
 By default, this command generates a factory for the request handler it
 creates, and registers it with the container. Passing this option disables
 that feature.
 EOT;
 
-    const HELP_OPT_NO_REGISTER = <<< 'EOT'
+    const HELP_HANDLER_OPT_NO_REGISTER = <<< 'EOT'
 By default, when this command generates a factory for the request handler it
 creates, it registers it with the container. Passing this option disables
 registration of the generated factory with the container.
 EOT;
+
+    public const HELP_ACTION_DESCRIPTION = 'Create an action class file.';
+
+    public const HELP_ACTION = <<< 'EOT'
+Creates an action class file named after the provided class. For a path, it
+matches the class namespace against PSR-4 autoloader namespaces in your
+composer.json.
+EOT;
+
+    public const HELP_ACTION_ARG_ACTION = <<< 'EOT'
+Fully qualified class name of the action class to create. This value
+should be quoted to ensure namespace separators are not interpreted as
+escape sequences by your shell.
+EOT;
+
+    const HELP_ACTION_OPT_NO_FACTORY = <<< 'EOT'
+By default, this command generates a factory for the action class it creates,
+and registers it with the container. Passing this option disables that
+feature.
+EOT;
+
+    const HELP_ACTION_OPT_NO_REGISTER = <<< 'EOT'
+By default, when this command generates a factory for the action class it
+creates, it registers it with the container. Passing this option disables
+registration of the generated factory with the container.
+EOT;
+
+    const STATUS_HANDLER_TEMPLATE = '<info>Creating request handler %s...</info>';
+
+    const STATUS_ACTION_TEMPLATE = '<info>Creating action %s...</info>';
+
+    /**
+     * Name of the argument that resolves to the new handler's name.
+     *
+     * @var string
+     */
+    private $handlerArgument = 'handler';
 
     /**
      * Flag indicating whether or not to require the generated handler before
@@ -56,18 +95,34 @@ EOT;
 
     /**
      * Configure the console command.
+     *
+     * If the command is named `action:create`, this method sets the
+     * $handlerArgument to "action", and then invokes the configureAction()
+     * method before returning. Otherwise, it configures the command for
+     * producing a handler.
      */
     protected function configure() : void
     {
-        $this->handlerArgument = (bool) preg_match('/^action:/', $this->getName())
-            ? 'action'
-            : 'handler'; // default argument
+        if (0 === strpos($this->getName(), 'action:')) {
+            $this->handlerArgument = 'action';
+            $this->configureAction();
+            return;
+        }
 
-        $this->setDescription('Create a PSR-15 request handler class file.');
-        $this->setHelp(self::HELP);
-        $this->addArgument($this->handlerArgument, InputArgument::REQUIRED, self::HELP_ARG_HANDLER);
-        $this->addOption('no-factory', null, InputOption::VALUE_NONE, self::HELP_OPT_NO_FACTORY);
-        $this->addOption('no-register', null, InputOption::VALUE_NONE, self::HELP_OPT_NO_REGISTER);
+        $this->setDescription(self::HELP_HANDLER_DESCRIPTION);
+        $this->setHelp(self::HELP_HANDLER);
+        $this->addArgument('handler', InputArgument::REQUIRED, self::HELP_HANDLER_ARG_HANDLER);
+        $this->addOption('no-factory', null, InputOption::VALUE_NONE, self::HELP_HANDLER_OPT_NO_FACTORY);
+        $this->addOption('no-register', null, InputOption::VALUE_NONE, self::HELP_HANDLER_OPT_NO_REGISTER);
+    }
+
+    protected function configureAction() : void
+    {
+        $this->setDescription(self::HELP_ACTION_DESCRIPTION);
+        $this->setHelp(self::HELP_ACTION);
+        $this->addArgument('action', InputArgument::REQUIRED, self::HELP_ACTION_ARG_ACTION);
+        $this->addOption('no-factory', null, InputOption::VALUE_NONE, self::HELP_ACTION_OPT_NO_FACTORY);
+        $this->addOption('no-register', null, InputOption::VALUE_NONE, self::HELP_ACTION_OPT_NO_REGISTER);
     }
 
     /**
@@ -79,7 +134,10 @@ EOT;
     {
         $handler = $input->getArgument($this->handlerArgument);
 
-        $output->writeln(sprintf('<info>Creating request handler %s...</info>', $handler));
+        $template = $this->handlerArgument === 'action'
+            ? self::STATUS_ACTION_TEMPLATE
+            : self::STATUS_HANDLER_TEMPLATE;
+        $output->writeln(sprintf($template, $handler));
 
         $generator = new CreateHandler();
         $path = $generator->process($handler);

--- a/test/CreateHandler/CreateHandlerCommandTest.php
+++ b/test/CreateHandler/CreateHandlerCommandTest.php
@@ -40,11 +40,16 @@ class CreateHandlerCommandTest extends TestCase
         $this->output = $this->prophesize(ConsoleOutputInterface::class);
 
         $this->command = new CreateHandlerCommand('handler:create');
+    }
 
-        // Do not require the generated handler during testing
-        $r = new ReflectionProperty($this->command, 'requireHandlerBeforeGeneratingFactory');
+    /**
+     * Allows disabling of the `require` statement in the command class when testing.
+     */
+    private function disableRequireHandlerDirective(CreateHandlerCommand $command) : void
+    {
+        $r = new ReflectionProperty($command, 'requireHandlerBeforeGeneratingFactory');
         $r->setAccessible(true);
-        $r->setValue($this->command, false);
+        $r->setValue($command, false);
     }
 
     private function reflectExecuteMethod()
@@ -57,17 +62,17 @@ class CreateHandlerCommandTest extends TestCase
     /**
      * @return ObjectProphecy|Application
      */
-    private function mockApplication()
+    private function mockApplication(string $forService = 'Foo\TestHandler')
     {
         $helperSet = $this->prophesize(HelperSet::class)->reveal();
 
         $factoryCommand = $this->prophesize(Command::class);
         $factoryCommand
             ->run(
-                Argument::that(function ($input) {
+                Argument::that(function ($input) use ($forService) {
                     Assert::assertInstanceOf(ArrayInput::class, $input);
                     Assert::assertContains('factory:create', (string) $input);
-                    Assert::assertContains('Foo\TestHandler', (string) $input);
+                    Assert::assertContains($forService, (string) $input);
                     return $input;
                 }),
                 $this->output->reveal()
@@ -83,31 +88,45 @@ class CreateHandlerCommandTest extends TestCase
 
     public function testConfigureSetsExpectedDescription()
     {
-        $this->assertContains('Create a PSR-15 request handler', $this->command->getDescription());
+        $this->assertContains(CreateHandlerCommand::HELP_HANDLER_DESCRIPTION, $this->command->getDescription());
+    }
+
+    public function testConfigureSetsExpectedDescriptionWhenRequestingAnAction()
+    {
+        $command = new CreateHandlerCommand('action:create');
+        $this->assertContains(CreateHandlerCommand::HELP_ACTION_DESCRIPTION, $command->getDescription());
     }
 
     public function testConfigureSetsExpectedHelp()
     {
-        $this->assertEquals(CreateHandlerCommand::HELP, $this->command->getHelp());
+        $this->assertEquals(CreateHandlerCommand::HELP_HANDLER, $this->command->getHelp());
+    }
+
+    public function testConfigureSetsExpectedHelpWhenRequestingAnAction()
+    {
+        $command = new CreateHandlerCommand('action:create');
+        $this->assertEquals(CreateHandlerCommand::HELP_ACTION, $command->getHelp());
     }
 
     public function testConfigureSetsExpectedArguments()
     {
         $definition = $this->command->getDefinition();
         $this->assertTrue($definition->hasArgument('handler'));
+        $this->assertFalse($definition->hasArgument('action'));
         $argument = $definition->getArgument('handler');
         $this->assertTrue($argument->isRequired());
-        $this->assertEquals(CreateHandlerCommand::HELP_ARG_HANDLER, $argument->getDescription());
+        $this->assertEquals(CreateHandlerCommand::HELP_HANDLER_ARG_HANDLER, $argument->getDescription());
     }
 
-    public function testConfigureSetsArgumentNameDifferentlyIfAnActionIsRequest()
+    public function testConfigureSetsExpectedArgumentsWhenRequestingAnAction()
     {
         $command = new CreateHandlerCommand('action:create');
         $definition = $command->getDefinition();
         $this->assertTrue($definition->hasArgument('action'));
+        $this->assertFalse($definition->hasArgument('handler'));
         $argument = $definition->getArgument('action');
         $this->assertTrue($argument->isRequired());
-        $this->assertEquals(CreateHandlerCommand::HELP_ARG_HANDLER, $argument->getDescription());
+        $this->assertEquals(CreateHandlerCommand::HELP_ACTION_ARG_ACTION, $argument->getDescription());
     }
 
     public function testConfigureSetsExpectedOptions()
@@ -117,16 +136,33 @@ class CreateHandlerCommandTest extends TestCase
         $this->assertTrue($definition->hasOption('no-factory'));
         $option = $definition->getOption('no-factory');
         $this->assertFalse($option->acceptValue());
-        $this->assertEquals(CreateHandlerCommand::HELP_OPT_NO_FACTORY, $option->getDescription());
+        $this->assertEquals(CreateHandlerCommand::HELP_HANDLER_OPT_NO_FACTORY, $option->getDescription());
 
         $this->assertTrue($definition->hasOption('no-register'));
         $option = $definition->getOption('no-register');
         $this->assertFalse($option->acceptValue());
-        $this->assertEquals(CreateHandlerCommand::HELP_OPT_NO_REGISTER, $option->getDescription());
+        $this->assertEquals(CreateHandlerCommand::HELP_HANDLER_OPT_NO_REGISTER, $option->getDescription());
+    }
+
+    public function testConfigureSetsExpectedOptionsWhenRequestingAnAction()
+    {
+        $command = new CreateHandlerCommand('action:create');
+        $definition = $command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('no-factory'));
+        $option = $definition->getOption('no-factory');
+        $this->assertFalse($option->acceptValue());
+        $this->assertEquals(CreateHandlerCommand::HELP_ACTION_OPT_NO_FACTORY, $option->getDescription());
+
+        $this->assertTrue($definition->hasOption('no-register'));
+        $option = $definition->getOption('no-register');
+        $this->assertFalse($option->acceptValue());
+        $this->assertEquals(CreateHandlerCommand::HELP_ACTION_OPT_NO_REGISTER, $option->getDescription());
     }
 
     public function testSuccessfulExecutionEmitsExpectedMessages()
     {
+        $this->disableRequireHandlerDirective($this->command);
         $this->command->setApplication($this->mockApplication()->reveal());
 
         $generator = Mockery::mock('overload:' . CreateHandler::class);
@@ -152,6 +188,40 @@ class CreateHandlerCommandTest extends TestCase
 
         $this->assertSame(0, $method->invoke(
             $this->command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+    }
+
+    public function testSuccessfulExecutionEmitsExpectedMessagesWhenRequestingAnAction()
+    {
+        $command = new CreateHandlerCommand('action:create');
+        $this->disableRequireHandlerDirective($command);
+        $command->setApplication($this->mockApplication('Foo\TestAction')->reveal());
+
+        $generator = Mockery::mock('overload:' . CreateHandler::class);
+        $generator->shouldReceive('process')
+            ->once()
+            ->with('Foo\TestAction')
+            ->andReturn(__DIR__);
+
+        $this->input->getArgument('action')->willReturn('Foo\TestAction');
+        $this->input->getOption('no-factory')->willReturn(false);
+        $this->input->getOption('no-register')->willReturn(false);
+        $this->output
+            ->writeln(Argument::containingString('Creating action Foo\TestAction'))
+            ->shouldBeCalled();
+        $this->output
+            ->writeln(Argument::containingString('Success'))
+            ->shouldBeCalled();
+        $this->output
+            ->writeln(Argument::containingString('Created class Foo\TestAction, in file ' . __DIR__))
+            ->shouldBeCalled();
+
+        $method = $this->reflectExecuteMethod();
+
+        $this->assertSame(0, $method->invoke(
+            $command,
             $this->input->reveal(),
             $this->output->reveal()
         ));

--- a/test/CreateHandler/CreateHandlerCommandTest.php
+++ b/test/CreateHandler/CreateHandlerCommandTest.php
@@ -100,6 +100,16 @@ class CreateHandlerCommandTest extends TestCase
         $this->assertEquals(CreateHandlerCommand::HELP_ARG_HANDLER, $argument->getDescription());
     }
 
+    public function testConfigureSetsArgumentNameDifferentlyIfAnActionIsRequest()
+    {
+        $command = new CreateHandlerCommand('action:create');
+        $definition = $command->getDefinition();
+        $this->assertTrue($definition->hasArgument('action'));
+        $argument = $definition->getArgument('action');
+        $this->assertTrue($argument->isRequired());
+        $this->assertEquals(CreateHandlerCommand::HELP_ARG_HANDLER, $argument->getDescription());
+    }
+
     public function testConfigureSetsExpectedOptions()
     {
         $definition = $this->command->getDefinition();


### PR DESCRIPTION
Essentially, it's the same command as `handler:create`, just with a different name during instantiation. When `action:create` is used, the required argument is renamed to `action` as well.

Fixes #51