### PR TITLE
Added new command migrate:middleware-to-request-handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ $ composer require --dev zendframework/zend-expressive-tooling
   - **middleware:create**: Create a PSR-15 middleware class file.
   - **migrate:interop-middleware**: Migrate interop middlewares and delegators
     to PSR-15 middlewares and request handlers.
+  - **migrate:middleware-to-request-handler**: Migrate PSR-15 middlewares to
+    request handlers.
   - **module:create**: Create and register a middleware module with the
     application.
   - **module:deregister**: Deregister a middleware module from the application.

--- a/bin/expressive
+++ b/bin/expressive
@@ -1,10 +1,10 @@
 #!/usr/bin/env php
-<?php // @codingStandardsIgnoreFile
+<?php
 /**
  * Wrapper for all other commands
  *
  * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
  */
 
@@ -35,6 +35,9 @@ $application->addCommands([
     new CreateHandler\CreateHandlerCommand('handler:create'),
     new CreateMiddleware\CreateMiddlewareCommand('middleware:create'),
     new MigrateInteropMiddleware\MigrateInteropMiddlewareCommand('migrate:interop-middleware'),
+    new MigrateMiddlewareToRequestHandler\MigrateMiddlewareToRequestHandlerCommand(
+        'migrate:middleware-to-request-handler'
+    ),
     new Module\CreateCommand('module:create'),
     new Module\DeregisterCommand('module:deregister'),
     new Module\RegisterCommand('module:register'),

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,7 +3,10 @@
     <rule ref="./vendor/zendframework/zend-coding-standard/ruleset.xml"/>
 
     <!-- Paths to check -->
+    <file>bin/bump-version</file>
+    <file>bin/expressive</file>
     <file>src</file>
     <file>test</file>
+
     <exclude-pattern>*/TestAsset/*</exclude-pattern>
 </ruleset>

--- a/src/MigrateMiddlewareToRequestHandler/ArgvException.php
+++ b/src/MigrateMiddlewareToRequestHandler/ArgvException.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Tooling\MigrateMiddlewareToRequestHandler;
+
+use RuntimeException;
+
+class ArgvException extends RuntimeException
+{
+}

--- a/src/MigrateMiddlewareToRequestHandler/ConvertMiddleware.php
+++ b/src/MigrateMiddlewareToRequestHandler/ConvertMiddleware.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Tooling\MigrateMiddlewareToRequestHandler;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ConvertMiddleware
+{
+    private $output;
+
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    public function process(string $directory) : void
+    {
+        $rdi = new RecursiveDirectoryIterator($directory);
+        $rii = new RecursiveIteratorIterator($rdi);
+
+        foreach ($rii as $file) {
+            if (! $this->isPhpFile($file)) {
+                continue;
+            }
+
+            $this->processFile((string) $file);
+        }
+    }
+
+    private function isPhpFile(SplFileInfo $file) : bool
+    {
+        return $file->isFile()
+            && $file->getExtension() === 'php'
+            && $file->isReadable()
+            && $file->isWritable();
+    }
+
+    private function processFile(string $filename) : void
+    {
+        $original = file_get_contents($filename);
+        $contents = $original;
+
+        if (! preg_match(
+            '#use\s+Psr\\\\Http\\\\Server\\\\MiddlewareInterface(\s*)(;|as\s*([^;\s]+)\s*;)#',
+            $contents,
+            $matches
+        )) {
+            return;
+        }
+
+        $middleware = $matches[2] === ';'
+            ? 'MiddlewareInterface'
+            : $matches[3];
+
+        // Remove imported MiddlewareInterface
+        $contents = preg_replace(
+            '#use\s+Psr\\\\Http\\\\Server\\\\MiddlewareInterface(.*);\n?#',
+            '',
+            $contents
+        );
+
+        // Change process to handle function and remove 2nd parameter
+        $contents = preg_replace(
+            '#(public\s+function\s+)(process)(\s*\(.*?)(,.*?)(\s*\))#s',
+            '\\1handle\\3\\5',
+            $contents
+        );
+
+        // Remove alias from imported RequestHandlerInterface
+        $contents = preg_replace(
+            '#(use\s+Psr\\\\Http\\\\Server\\\\RequestHandlerInterface).*;#',
+            '\\1;',
+            $contents
+        );
+
+        // Change implemented interface on the class from MiddlewareInterface to RequestHandlerInterface
+        $contents = preg_replace(
+            '#(class\s+.*implements\s+[^{]*,?\s*)' . preg_quote($middleware, '#') . '(,|\s|{)#',
+            '\\1RequestHandlerInterface\\2',
+            $contents
+        );
+
+        if ($original === $contents) {
+            return;
+        }
+
+        $this->output->writeln(sprintf('<info>- Updating %s</info>', $filename));
+
+        file_put_contents($filename, $contents);
+    }
+}

--- a/src/MigrateMiddlewareToRequestHandler/MigrateMiddlewareToRequestHandlerCommand.php
+++ b/src/MigrateMiddlewareToRequestHandler/MigrateMiddlewareToRequestHandlerCommand.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Tooling\MigrateMiddlewareToRequestHandler;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MigrateMiddlewareToRequestHandlerCommand extends Command
+{
+    private const DEFAULT_SRC = '/src';
+
+    private const HELP = <<< 'EOT'
+Migrate PSR-15 middlewares to request handlers.
+
+Scans all PHP files under the --src directory for PSR-15 middlewares
+and change them into request handlers. This can be used to action
+middlewares, which are bind to routes and does not use request handlers.
+EOT;
+
+    private const HELP_OPT_SRC = <<< 'EOT'
+Specify a path to PHP files to migrate PSR-15 middlewares.
+If not specified, assumes src/ under the current working path.
+EOT;
+
+    /**
+     * @var null|string Path from which to resolve default src directory
+     */
+    private $projectDir;
+
+    /**
+     * @var null|string Project root against which to scan.
+     */
+    public function setProjectDir(?string $path) : void
+    {
+        $this->projectDir = $path;
+    }
+
+    /**
+     * Retrieve the project root directory.
+     *
+     * Uses result of getcwd() if not previously set.
+     */
+    private function getProjectDir() : string
+    {
+        return $this->projectDir ?: getcwd();
+    }
+
+    protected function configure() : void
+    {
+        $this->setDescription('Migrate PSR-15 middlewares to request handlers');
+        $this->setHelp(self::HELP);
+        $this->addOption('src', 's', InputOption::VALUE_REQUIRED, self::HELP_OPT_SRC);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        $src = $this->getSrcDir($input);
+
+        $output->writeln('<info>Scanning for PSR-15 middlewares to convert...</info>');
+
+        $converter = new ConvertMiddleware($output);
+        $converter->process($src);
+
+        $output->writeln('<info>Done!</info>');
+
+        return 0;
+    }
+
+    /**
+     * @throws ArgvException
+     */
+    private function getSrcDir(InputInterface $input) : string
+    {
+        $path = $input->getOption('src') ?: self::DEFAULT_SRC;
+        $path = $this->getProjectDir() . '/' . $path;
+
+        if (! is_dir($path)) {
+            throw new ArgvException(sprintf(
+                'Invalid --src argument "%s"; directory does not exist',
+                $path
+            ));
+        }
+
+        return $path;
+    }
+}

--- a/test/MigrateMiddlewareToRequestHandler/ConvertMiddlewareTest.php
+++ b/test/MigrateMiddlewareToRequestHandler/ConvertMiddlewareTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Zend\Expressive\Tooling\MigrateMiddlewareToRequestHandler\ConvertMiddleware;
+
+class ConvertMiddlewareTest extends TestCase
+{
+    use ProjectSetupTrait;
+
+    public function testConvertsFilesAndEmitsInfoMessagesAsExpected()
+    {
+        $dir = vfsStream::setup('migrate');
+        $this->setupSrcDir($dir);
+        $path = vfsStream::url('migrate');
+
+        $console = $this->setupConsoleHelper();
+
+        $converter = new ConvertMiddleware($console->reveal());
+        $converter->process($path);
+
+        self::assertExpected($path);
+    }
+}

--- a/test/MigrateMiddlewareToRequestHandler/MigrateMiddlewareToRequestHandlerCommandTest.php
+++ b/test/MigrateMiddlewareToRequestHandler/MigrateMiddlewareToRequestHandlerCommandTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use ReflectionClass;
+use ReflectionMethod;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Zend\Expressive\Tooling\MigrateMiddlewareToRequestHandler\ArgvException;
+use Zend\Expressive\Tooling\MigrateMiddlewareToRequestHandler\ConvertMiddleware;
+use Zend\Expressive\Tooling\MigrateMiddlewareToRequestHandler\MigrateMiddlewareToRequestHandlerCommand;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class MigrateMiddlewareToRequestHandlerCommandTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /** @var InputInterface|ObjectProphecy */
+    private $input;
+
+    /** @var ConsoleOutputInterface|ObjectProphecy */
+    private $output;
+
+    /** @var MigrateMiddlewareToRequestHandlerCommand */
+    private $command;
+
+    protected function setUp() : void
+    {
+        $this->input = $this->prophesize(InputInterface::class);
+        $this->output = $this->prophesize(ConsoleOutputInterface::class);
+
+        $this->command = new MigrateMiddlewareToRequestHandlerCommand('migrate:middleware-to-request-handler');
+    }
+
+    private function reflectExecuteMethod() : ReflectionMethod
+    {
+        $r = new ReflectionMethod($this->command, 'execute');
+        $r->setAccessible(true);
+        return $r;
+    }
+
+    public function testConfigureSetsExpectedDescription()
+    {
+        $this->assertContains('Migrate PSR-15 middlewares to request handlers', $this->command->getDescription());
+    }
+
+    /**
+     * @return mixed
+     */
+    private function getConstantValue(string $const, string $class = MigrateMiddlewareToRequestHandlerCommand::class)
+    {
+        $r = new ReflectionClass($class);
+
+        return $r->getConstant($const);
+    }
+
+    public function testConfigureSetsExpectedHelp()
+    {
+        $this->assertEquals($this->getConstantValue('HELP'), $this->command->getHelp());
+    }
+
+    public function testConfigureSetsExpectedArguments()
+    {
+        $definition = $this->command->getDefinition();
+        $this->assertTrue($definition->hasOption('src'));
+        $option = $definition->getOption('src');
+        $this->assertTrue($option->isValueRequired());
+        $this->assertEquals($this->getConstantValue('HELP_OPT_SRC'), $option->getDescription());
+    }
+
+    public function testSuccessfulExecutionEmitsExpectedMessages()
+    {
+        vfsStream::setup('migrate');
+        $path = vfsStream::url('migrate');
+        mkdir($path . '/src');
+
+        $converter = Mockery::mock('overload:' . ConvertMiddleware::class);
+        $converter->shouldReceive('process')
+            ->once()
+            ->with($path . '/src')
+            ->andReturnNull();
+
+        $this->input->getOption('src')->willReturn('src');
+
+        $this->output
+            ->writeln(Argument::containingString('Scanning for PSR-15 middlewares to convert...'))
+            ->shouldBeCalled();
+        $this->output
+            ->writeln(Argument::containingString('Done!'))
+            ->shouldBeCalled();
+
+        $this->command->setProjectDir($path);
+        $method = $this->reflectExecuteMethod();
+
+        $this->assertSame(0, $method->invoke(
+            $this->command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+    }
+
+    public function testAllowsExceptionsFromInvalidSrcDirectoryArgumentToBubbleUp()
+    {
+        vfsStream::setup('migrate');
+        $path = vfsStream::url('migrate');
+
+        $converter = Mockery::mock('overload:' . ConvertMiddleware::class);
+        $converter->shouldNotReceive('process');
+
+        $this->input->getOption('src')->willReturn('src');
+
+        $this->command->setProjectDir($path);
+        $method = $this->reflectExecuteMethod();
+
+        $this->expectException(ArgvException::class);
+        $this->expectExceptionMessage('Invalid --src argument');
+
+        $method->invoke(
+            $this->command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        );
+    }
+}

--- a/test/MigrateMiddlewareToRequestHandler/ProjectSetupTrait.php
+++ b/test/MigrateMiddlewareToRequestHandler/ProjectSetupTrait.php
@@ -56,19 +56,29 @@ trait ProjectSetupTrait
         $console = $this->prophesize(OutputInterface::class);
 
         $console
-            ->writeln(Argument::containingString('src/MultilineMiddleware.php'))
+            ->writeln(Argument::that(function ($arg) {
+                return preg_match('#Updating .*src/MultilineMiddleware\.php#', $arg) !== false;
+            }))
             ->shouldBeCalled();
         $console
-            ->writeln(Argument::containingString('src/MultipleInterfacesMiddleware.php'))
+            ->writeln(Argument::that(function ($arg) {
+                return preg_match('#Updating .*src/MultipleInterfacesMiddleware\.php#', $arg) !== false;
+            }))
             ->shouldBeCalled();
         $console
-            ->writeln(Argument::containingString('src/MyActionWithAliases.php'))
+            ->writeln(Argument::that(function ($arg) {
+                return preg_match('#Updating .*src/MyActionWithAliases\.php#', $arg) !== false;
+            }))
             ->shouldBeCalled();
-//        $console
-//            ->writeln(Argument::containingString('src/MyInteropMiddleware.php'))
-//            ->shouldBeCalled();
         $console
-            ->writeln(Argument::containingString('src/MyMiddleware.php'))
+            ->writeln(Argument::that(function ($arg) {
+                return preg_match('#Updating .*src/MyMiddleware\.php#', $arg) !== false;
+            }))
+            ->shouldBeCalled();
+        $console
+            ->writeln(Argument::that(function ($arg) {
+                return preg_match('#Skipping .*src/MyMiddlewareWithHandler\.php#', $arg) !== false;
+            }))
             ->shouldBeCalled();
 
         return $console;

--- a/test/MigrateMiddlewareToRequestHandler/ProjectSetupTrait.php
+++ b/test/MigrateMiddlewareToRequestHandler/ProjectSetupTrait.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\Assert;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use Symfony\Component\Console\Output\OutputInterface;
+
+trait ProjectSetupTrait
+{
+    private function setupSrcDir($dir) : void
+    {
+        $base = realpath(__DIR__ . '/TestAsset') . DIRECTORY_SEPARATOR;
+        $rdi = new RecursiveDirectoryIterator($base . 'src');
+        $rii = new RecursiveIteratorIterator($rdi);
+
+        foreach ($rii as $file) {
+            if (! $this->isPhpFile($file)) {
+                continue;
+            }
+
+            $filename = $file->getRealPath();
+            $contents = file_get_contents($filename);
+            $name = strtr($filename, [$base => '', DIRECTORY_SEPARATOR => '/']);
+            vfsStream::newFile($name)
+                ->at($dir)
+                ->setContent($contents);
+        }
+    }
+
+    private static function isPhpFile(SplFileInfo $file) : bool
+    {
+        return $file->isFile()
+            && $file->getExtension() === 'php'
+            && $file->isReadable()
+            && $file->isWritable();
+    }
+
+    /**
+     * @return OutputInterface|ObjectProphecy
+     */
+    private function setupConsoleHelper()
+    {
+        $console = $this->prophesize(OutputInterface::class);
+
+        $console
+            ->writeln(Argument::containingString('src/MultilineMiddleware.php'))
+            ->shouldBeCalled();
+        $console
+            ->writeln(Argument::containingString('src/MultipleInterfacesMiddleware.php'))
+            ->shouldBeCalled();
+        $console
+            ->writeln(Argument::containingString('src/MyActionWithAliases.php'))
+            ->shouldBeCalled();
+//        $console
+//            ->writeln(Argument::containingString('src/MyInteropMiddleware.php'))
+//            ->shouldBeCalled();
+        $console
+            ->writeln(Argument::containingString('src/MyMiddleware.php'))
+            ->shouldBeCalled();
+
+        return $console;
+    }
+
+    public static function assertExpected(string $dir) : void
+    {
+        $base = $dir;
+        $rdi = new RecursiveDirectoryIterator($dir);
+        $rii = new RecursiveIteratorIterator($rdi);
+
+        /** @var SplFileInfo $file */
+        foreach ($rii as $file) {
+            if (! self::isPhpFile($file)) {
+                continue;
+            }
+
+            $filename = $file->getPathname();
+            $content = file_get_contents($filename);
+            $name = strtr($filename, [$base . '/src' => __DIR__ . '/TestAsset/expected', DIRECTORY_SEPARATOR => '/']);
+
+            Assert::assertStringEqualsFile($name, $content);
+        }
+    }
+}

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MultilineMiddleware.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MultilineMiddleware.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
 

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MultilineMiddleware.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MultilineMiddleware.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Diactoros\Response;
+
+class MultilineMiddleware implements RequestHandlerInterface
+{
+    public function handle(
+        ServerRequestInterface $request
+    ) : ResponseInterface {
+        return new Response();
+    }
+}

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MultipleInterfacesMiddleware.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MultipleInterfacesMiddleware.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
 

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MultipleInterfacesMiddleware.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MultipleInterfacesMiddleware.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Diactoros\Response\JsonResponse;
+
+class MultipleInterfacesMiddleware implements
+    MyInterface,
+    RequestHandlerInterface,
+    SomeInterface
+{
+    /**
+     * @param ServerRequestInterface $request
+     * @param DelegateInterface $delegate
+     * @return ResponseInterface
+     */
+    public function handle(ServerRequestInterface $request) : ResponseInterface {
+        return new JsonResponse(['status' => 1]);
+    }
+}

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MyActionWithAliases.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MyActionWithAliases.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Diactoros\Response;
+
+class MyActionWithAliases implements RequestHandlerInterface
+{
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        return new Response();
+    }
+}

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MyActionWithAliases.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MyActionWithAliases.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
 

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MyInteropMiddleware.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MyInteropMiddleware.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
 

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MyInteropMiddleware.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MyInteropMiddleware.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
+
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class MyInteropMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    {
+        $response = $delegate->process($request);
+
+        $another = $request->getAttribute('my-attribute');
+        $another->process($request);
+
+        return $response;
+    }
+}

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MyMiddleware.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MyMiddleware.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
 

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MyMiddleware.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MyMiddleware.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Diactoros\Response;
+
+class MyMiddleware implements RequestHandlerInterface
+{
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        return new Response();
+    }
+}

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MyMiddlewareWithHandler.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MyMiddlewareWithHandler.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
 

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MyMiddlewareWithHandler.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/expected/MyMiddlewareWithHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Diactoros\Response;
+
+class MyMiddlewareWithHandler implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        if ($request->getHeader('X-Header')) {
+            return $handler->handle($request);
+        }
+
+        return new Response();
+    }
+}

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MultilineMiddleware.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MultilineMiddleware.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface as DelegateInterface;
+use Zend\Diactoros\Response;
+
+class MultilineMiddleware implements MiddlewareInterface
+{
+    public function process(
+        ServerRequestInterface $request,
+        DelegateInterface $delegate
+    ) : ResponseInterface {
+        return new Response();
+    }
+}

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MultilineMiddleware.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MultilineMiddleware.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
 

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MultipleInterfacesMiddleware.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MultipleInterfacesMiddleware.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
 

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MultipleInterfacesMiddleware.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MultipleInterfacesMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface as DelegateInterface;
+use Zend\Diactoros\Response\JsonResponse;
+
+class MultipleInterfacesMiddleware implements
+    MyInterface,
+    MiddlewareInterface,
+    SomeInterface
+{
+    /**
+     * @param ServerRequestInterface $request
+     * @param DelegateInterface $delegate
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate) : ResponseInterface {
+        return new JsonResponse(['status' => 1]);
+    }
+}

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MyActionWithAliases.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MyActionWithAliases.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
 

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MyActionWithAliases.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MyActionWithAliases.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
+use Zend\Diactoros\Response;
+
+class MyActionWithAliases implements Middleware
+{
+    public function process(ServerRequestInterface $request, Handler $handler) : ResponseInterface
+    {
+        return new Response();
+    }
+}

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MyInteropMiddleware.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MyInteropMiddleware.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
 

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MyInteropMiddleware.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MyInteropMiddleware.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
+
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class MyInteropMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    {
+        $response = $delegate->process($request);
+
+        $another = $request->getAttribute('my-attribute');
+        $another->process($request);
+
+        return $response;
+    }
+}

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MyMiddleware.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MyMiddleware.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
 

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MyMiddleware.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MyMiddleware.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Diactoros\Response;
+
+class MyMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        return new Response();
+    }
+}

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MyMiddlewareWithHandler.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MyMiddlewareWithHandler.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
 

--- a/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MyMiddlewareWithHandler.php
+++ b/test/MigrateMiddlewareToRequestHandler/TestAsset/src/MyMiddlewareWithHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ZendTest\Expressive\Tooling\MigrateMiddlewareToRequestHandler\TestAsset;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Diactoros\Response;
+
+class MyMiddlewareWithHandler implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        if ($request->getHeader('X-Header')) {
+            return $handler->handle($request);
+        }
+
+        return new Response();
+    }
+}


### PR DESCRIPTION
Convert PSR-15 middleware to request handler in given path. It should be used to convert final middlewres binded to routes which are not using delegator/request handler.

Works only with PSR-15 middlewares (if you have interop middlewares migrate them first to PSR-15 middlewares by migrate:interop-middleware and then convert them to request handlers).
