### PR TITLE
Mark migratate:interop-middleware as deprecated

### DIFF
--- a/src/MigrateInteropMiddleware/ArgvException.php
+++ b/src/MigrateInteropMiddleware/ArgvException.php
@@ -11,6 +11,9 @@ namespace Zend\Expressive\Tooling\MigrateInteropMiddleware;
 
 use RuntimeException;
 
+/**
+ * @deprecated since 1.0.0, and scheduled for removal with 2.0.0
+ */
 class ArgvException extends RuntimeException
 {
 }

--- a/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
+++ b/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
@@ -14,6 +14,9 @@ use RecursiveIteratorIterator;
 use SplFileInfo;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @deprecated since 1.0.0, and scheduled for removal with 2.0.0
+ */
 class ConvertInteropMiddleware
 {
     private $output;

--- a/src/MigrateInteropMiddleware/MigrateInteropMiddlewareCommand.php
+++ b/src/MigrateInteropMiddleware/MigrateInteropMiddlewareCommand.php
@@ -14,6 +14,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @deprecated since 1.0.0, and scheduled for removal with 2.0.0
+ */
 class MigrateInteropMiddlewareCommand extends Command
 {
     private const DEFAULT_SRC = '/src';


### PR DESCRIPTION
We need just for migration from v2->v3 expressive so that command
should be remvoved in future, probably in version 2
