### PR TITLE
Set package version from ocramius/package-versions library

### DIFF
--- a/bin/expressive
+++ b/bin/expressive
@@ -12,9 +12,8 @@ declare(strict_types=1);
 
 namespace Zend\Expressive\Tooling;
 
+use PackageVersions\Versions;
 use Symfony\Component\Console\Application;
-
-const VERSION = '%version%';
 
 // Setup/verify autoloading
 if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
@@ -28,7 +27,9 @@ if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
     exit(1);
 }
 
-$application = new Application('expressive', VERSION);
+$version = strstr(Versions::getVersion('zendframework/zend-expressive-tooling'), '@', true);
+
+$application = new Application('expressive', $version);
 $application->addCommands([
     new Factory\CreateFactoryCommand('factory:create'),
     new CreateHandler\CreateHandlerCommand('action:create'),

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.1",
+        "ocramius/package-versions": "^1.3",
         "symfony/console": "^2.8 || ^3.0 || ^4.0",
         "zendframework/zend-code": "^2.6.3 || ^3.3",
         "zendframework/zend-component-installer": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "15786d58bf4a9559adc22dcac54e1109",
+    "content-hash": "69e2e762eb5f68dd2800a6ed7402cec2",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -55,6 +55,55 @@
                 "response"
             ],
             "time": "2017-02-09T16:10:21+00:00"
+        },
+        {
+            "name": "ocramius/package-versions",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/PackageVersions.git",
+                "reference": "4489d5002c49d55576fa0ba786f42dbb009be46f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/4489d5002c49d55576fa0ba786f42dbb009be46f",
+                "reference": "4489d5002c49d55576fa0ba786f42dbb009be46f",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0.0",
+                "php": "^7.1.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.6.3",
+                "ext-zip": "*",
+                "infection/infection": "^0.7.1",
+                "phpunit/phpunit": "^7.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "time": "2018-02-05T13:05:30+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
Because #62 has been closed this is alternative solution which uses `ocramius/package-versions` repository to set automatically version of the package in the command line tools.

We don't need to manually update it on every release.
