### PR TITLE
Added license docblock and strict type declaration in TestAssets

### DIFF
--- a/test/MigrateInteropMiddleware/TestAsset/expected/InteropAliasMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/expected/InteropAliasMiddleware.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
 

--- a/test/MigrateInteropMiddleware/TestAsset/expected/MultilineMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/expected/MultilineMiddleware.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
 

--- a/test/MigrateInteropMiddleware/TestAsset/expected/MultipleInterfacesMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/expected/MultipleInterfacesMiddleware.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
 

--- a/test/MigrateInteropMiddleware/TestAsset/expected/MyClass.php
+++ b/test/MigrateInteropMiddleware/TestAsset/expected/MyClass.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
 

--- a/test/MigrateInteropMiddleware/TestAsset/expected/MyInteropDelegate.php
+++ b/test/MigrateInteropMiddleware/TestAsset/expected/MyInteropDelegate.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
 

--- a/test/MigrateInteropMiddleware/TestAsset/expected/MyInteropMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/expected/MyInteropMiddleware.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
 

--- a/test/MigrateInteropMiddleware/TestAsset/src/InteropAliasMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/InteropAliasMiddleware.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
 

--- a/test/MigrateInteropMiddleware/TestAsset/src/MultilineMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/MultilineMiddleware.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
 

--- a/test/MigrateInteropMiddleware/TestAsset/src/MultipleInterfacesMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/MultipleInterfacesMiddleware.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
 

--- a/test/MigrateInteropMiddleware/TestAsset/src/MyClass.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/MyClass.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
 

--- a/test/MigrateInteropMiddleware/TestAsset/src/MyInteropDelegate.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/MyInteropDelegate.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
 

--- a/test/MigrateInteropMiddleware/TestAsset/src/MyInteropMiddleware.php
+++ b/test/MigrateInteropMiddleware/TestAsset/src/MyInteropMiddleware.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Tooling\MigrateInteropMiddleware\TestAsset;
 


### PR DESCRIPTION
- per https://github.com/zendframework/zend-expressive-tooling/pull/58#discussion_r168978833