### PR TITLE
Adds migrate:expressive-v2.2 command

### DIFF
--- a/bin/expressive
+++ b/bin/expressive
@@ -30,6 +30,7 @@ $application = new Application('expressive', VERSION);
 $application->addCommands([
     new CreateMiddleware\CreateMiddlewareCommand('middleware:create'),
     new GenerateProgrammaticPipelineFromConfig\PipelineFromConfigCommand('migrate:pipeline'),
+    new MigrateExpressive22\MigrateExpressive22Command('migrate:expressive-v2.2'),
     new MigrateOriginalMessageCalls\MigrateOriginalMessageCallsCommand('migrate:original-messages'),
     new ScanForErrorMiddleware\ScanForErrorMiddlewareCommand('migrate:error-middleware-scanner'),
     new Module\CreateCommand('module:create'),

--- a/src/MigrateExpressive22/MigrateExpressive22Command.php
+++ b/src/MigrateExpressive22/MigrateExpressive22Command.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Tooling\MigrateExpressive22;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MigrateExpressive22Command extends Command
+{
+    const HELP = <<< 'EOT'
+Migrate an Expressive application to version 2.2.
+
+This command does the following:
+
+- Adds entries for the zend-expressive and zend-expressive-router
+  ConfigProvider classes to config/config.php
+- Updates entries to pipeRoutingMiddleware() to instead pipe the
+  zend-expressive-router RouteMiddleware.
+- Updates entries to pipeDispatchMiddleware() to instead pipe the
+  zend-expressive-router DispatchMiddleware.
+- Updates entries to pipe the various Implicit*Middleware to pipe the
+  new zend-expressive-router versions.
+
+These changes are made to prepare your application for version 3, and to remove
+known deprecation messages.
+EOT;
+
+    /**
+     * @var null|string Root path of the application being updated; defaults to $PWD
+     */
+    private $projectDir;
+
+    /**
+     * @var null|string Project root in which to make updates.
+     */
+    public function setProjectDir($path)
+    {
+        $this->projectDir = $path;
+    }
+
+    /**
+     * Configure the console command.
+     */
+    protected function configure()
+    {
+        $this->setDescription('Migrate an Expressive application to version 2.2.');
+        $this->setHelp(self::HELP);
+    }
+
+    /**
+     * Execute console command.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int Exit status
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $projectDir = $this->getProjectDir();
+
+        $output->writeln('<info>Migrating application to Expressive 2.2...</info>');
+
+        $output->writeln('<info>- Updating config/config.php</info>');
+        $updateConfig = new UpdateConfig();
+        $updateConfig($output, $projectDir);
+
+        $output->writeln('<info>- Updating config/pipeline.php</info>');
+        $updatePipeline = new UpdatePipeline();
+        $updatePipeline($output, $projectDir);
+
+        $output->writeln('<info>Done!</info>');
+
+        return 0;
+    }
+
+    /**
+     * Retrieve the project root directory.
+     *
+     * Uses result of getcwd() if not previously set.
+     *
+     * @return string
+     */
+    private function getProjectDir()
+    {
+        return $this->projectDir ?: realpath(getcwd());
+    }
+}

--- a/src/MigrateExpressive22/UpdateConfig.php
+++ b/src/MigrateExpressive22/UpdateConfig.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Tooling\MigrateExpressive22;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UpdateConfig
+{
+    /**
+     * @param string $projectPath
+     * @return void
+     */
+    public function __invoke(OutputInterface $output, $projectPath)
+    {
+        $filename = sprintf('%s/config/config.php', $projectPath);
+        $contents = file_get_contents($filename);
+
+        $components = [
+            \Zend\Expressive\Router\ConfigProvider::class,
+            \Zend\Expressive\ConfigProvider::class,
+        ];
+
+        $pattern = sprintf(
+            "/(new (?:%s?%s)?ConfigAggregator\(\s*(?:array\(|\[)\s*)(?:\r|\n|\r\n)(\s*)/",
+            preg_quote('\\'),
+            preg_quote('Zend\ConfigAggregator\\')
+        );
+
+        $replacementTemplate = "\$1\n\$2\\%s::class,\n\$2";
+
+        foreach ($components as $component) {
+            $output->writeln(sprintf(
+                '<info>Adding %s to config/config.php</info>',
+                $component
+            ));
+            $replacement = sprintf($replacementTemplate, $component);
+            $contents = preg_replace($pattern, $replacement, $contents);
+        }
+
+        file_put_contents($filename, $contents);
+    }
+}

--- a/src/MigrateExpressive22/UpdatePipeline.php
+++ b/src/MigrateExpressive22/UpdatePipeline.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Tooling\MigrateExpressive22;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UpdatePipeline
+{
+    // @codingStandardsIgnoreStart
+    /**
+     * PCRE strings to match, and their replacements.
+     * @var string[]
+     */
+    private $matches = [
+        '/-\>pipeRoutingMiddleware\(\)/'                        => '->pipe(\Zend\Expressive\Router\Middleware\RouteMiddleware::class)',
+        '/-\>pipeDispatchMiddleware\(\)/'                       => '->pipe(\Zend\Expressive\Router\Middleware\DispatchMiddleware::class)',
+        '/-\>pipe\(.*?(Implicit(Head|Options)Middleware).*?\)/' => '->pipe(\Zend\Expressive\Router\Middleware\\\\$1::class)'
+    ];
+    // @codingStandardsIgnoreEnd
+
+    /**
+     * @param string $projectPath
+     * @return void
+     */
+    public function __invoke(OutputInterface $output, $projectPath)
+    {
+        $filename = sprintf('%s/config/pipeline.php', $projectPath);
+        $contents = '';
+        $fh = fopen($filename, 'r+');
+
+        while (! feof($fh)) {
+            if (false === ($line = fgets($fh))) {
+                break;
+            }
+
+            $contents .= $this->matchAndReplace($output, $line);
+        }
+
+        fclose($fh);
+
+        file_put_contents($filename, $contents);
+    }
+
+    /**
+     * @param string $line
+     * @return string
+     */
+    private function matchAndReplace(OutputInterface $output, $line)
+    {
+        $updated = $line;
+        foreach ($this->matches as $pattern => $replacement) {
+            $updated = preg_replace($pattern, $replacement, $updated);
+        }
+
+        if ($updated !== $line) {
+            $output->writeln(sprintf(
+                '<info>Rewrote line "%s" to "%s"</info>',
+                $line,
+                $updated
+            ));
+        }
+
+        return $updated;
+    }
+}

--- a/test/MigrateExpressive22/MigrateExpressive22CommandTest.php
+++ b/test/MigrateExpressive22/MigrateExpressive22CommandTest.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Tooling\MigrateExpressive22;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use ReflectionMethod;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Zend\Expressive\Tooling\MigrateExpressive22\MigrateExpressive22Command;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class MigrateOriginalMessageCallsCommandTest extends TestCase
+{
+    protected function setUp()
+    {
+        $this->root = vfsStream::setup('expressive22');
+        $this->url = vfsStream::url('expressive22');
+        mkdir($this->url . '/config');
+        touch($this->url . '/config/config.php');
+        touch($this->url . '/config/pipeline.php');
+
+        $this->input = $this->prophesize(InputInterface::class);
+        $this->output = $this->prophesize(OutputInterface::class);
+
+        $this->command = new MigrateExpressive22Command('migrate:expressive-v2.2');
+        $this->command->setProjectDir($this->url);
+    }
+
+    private function reflectExecuteMethod()
+    {
+        $r = new ReflectionMethod($this->command, 'execute');
+        $r->setAccessible(true);
+        return $r;
+    }
+
+    public function testConfigureSetsExpectedDescription()
+    {
+        $this->assertContains('Migrate an Expressive application to version 2.2', $this->command->getDescription());
+    }
+
+    public function testConfigureSetsExpectedHelp()
+    {
+        $this->assertEquals(MigrateExpressive22Command::HELP, $this->command->getHelp());
+    }
+
+    public function testCommandUpdatesConfigAndPipeline()
+    {
+        $config = sprintf('%s/config/config.php', $this->url);
+        $pipeline = sprintf('%s/config/pipeline.php', $this->url);
+
+        file_put_contents($config, $this->getOriginalConfig());
+        file_put_contents($pipeline, $this->getOriginalPipeline());
+
+        $this->output
+            ->writeln(Argument::containingString('Migrating application to Expressive 2.2'))
+            ->shouldBeCalled();
+
+        $this->output->writeln(Argument::containingString('- Updating config/config.php'))->shouldBeCalled();
+        $this->output
+            ->writeln(Argument::containingString('Adding Zend\Expressive\Router\ConfigProvider to config'))
+            ->shouldBeCalled();
+        $this->output
+            ->writeln(Argument::containingString('Adding Zend\Expressive\ConfigProvider to config'))
+            ->shouldBeCalled();
+
+        $this->output
+            ->writeln(Argument::containingString('- Updating config/pipeline.php'))
+            ->shouldBeCalled();
+        $this->output->writeln(Argument::containingString('pipeRoutingMiddleware()'))->shouldBeCalled();
+        $this->output->writeln(Argument::containingString('ImplicitHeadMiddleware'))->shouldBeCalled();
+        $this->output->writeln(Argument::containingString('ImplicitOptionsMiddleware'))->shouldBeCalled();
+        $this->output->writeln(Argument::containingString('pipeDispatchMiddleware()'))->shouldBeCalled();
+
+        $this->output
+            ->writeln(Argument::containingString('Done!'))
+            ->shouldBeCalled();
+
+        $method = $this->reflectExecuteMethod();
+        $this->assertSame(0, $method->invoke(
+            $this->command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+
+        $configAfterUpdate = file_get_contents($config);
+        $pipelineAfterUpdate = file_get_contents($pipeline);
+
+        $this->assertEquals(
+            $this->getExpectedConfig(),
+            $configAfterUpdate,
+            'Configuration was not updated as expected'
+        );
+        $this->assertEquals(
+            $this->getExpectedPipeline(),
+            $pipelineAfterUpdate,
+            'Pipeline was not updated as expected'
+        );
+    }
+
+    private function getOriginalConfig()
+    {
+        return <<< 'EOT'
+<?php
+
+use Zend\ConfigAggregator\ArrayProvider;
+use Zend\ConfigAggregator\ConfigAggregator;
+use Zend\ConfigAggregator\PhpFileProvider;
+
+// To enable or disable caching, set the `ConfigAggregator::ENABLE_CACHE` boolean in
+// `config/autoload/local.php`.
+$cacheConfig = [
+    'config_cache_path' => 'data/config-cache.php',
+];
+
+$aggregator = new ConfigAggregator([
+    // Include cache configuration
+    new ArrayProvider($cacheConfig),
+
+    // Default App module config
+    App\ConfigProvider::class,
+
+    // Load application config in a pre-defined order in such a way that local settings
+    // overwrite global settings. (Loaded as first to last):
+    //   - `global.php`
+    //   - `*.global.php`
+    //   - `local.php`
+    //   - `*.local.php`
+    new PhpFileProvider(realpath(__DIR__) . '/autoload/{{,*.}global,{,*.}local}.php'),
+
+    // Load development config if it exists
+    new PhpFileProvider(realpath(__DIR__) . '/development.config.php'),
+], $cacheConfig['config_cache_path']);
+
+return $aggregator->getMergedConfig();
+EOT;
+    }
+
+    private function getOriginalPipeline()
+    {
+        return <<< 'EOT'
+$app->pipeRoutingMiddleware();
+$app->pipe(\Zend\Expressive\Middleware\ImplicitHeadMiddleware::class);
+$app->pipe(\Zend\Expressive\Middleware\ImplicitOptionsMiddleware::class);
+$app->pipeDispatchMiddleware();
+EOT;
+    }
+
+    public function getExpectedConfig()
+    {
+        return <<< 'EOT'
+<?php
+
+use Zend\ConfigAggregator\ArrayProvider;
+use Zend\ConfigAggregator\ConfigAggregator;
+use Zend\ConfigAggregator\PhpFileProvider;
+
+// To enable or disable caching, set the `ConfigAggregator::ENABLE_CACHE` boolean in
+// `config/autoload/local.php`.
+$cacheConfig = [
+    'config_cache_path' => 'data/config-cache.php',
+];
+
+$aggregator = new ConfigAggregator([
+    \Zend\Expressive\ConfigProvider::class,
+    \Zend\Expressive\Router\ConfigProvider::class,
+    // Include cache configuration
+    new ArrayProvider($cacheConfig),
+
+    // Default App module config
+    App\ConfigProvider::class,
+
+    // Load application config in a pre-defined order in such a way that local settings
+    // overwrite global settings. (Loaded as first to last):
+    //   - `global.php`
+    //   - `*.global.php`
+    //   - `local.php`
+    //   - `*.local.php`
+    new PhpFileProvider(realpath(__DIR__) . '/autoload/{{,*.}global,{,*.}local}.php'),
+
+    // Load development config if it exists
+    new PhpFileProvider(realpath(__DIR__) . '/development.config.php'),
+], $cacheConfig['config_cache_path']);
+
+return $aggregator->getMergedConfig();
+EOT;
+    }
+
+    public function getExpectedPipeline()
+    {
+        return <<< 'EOT'
+$app->pipe(\Zend\Expressive\Router\Middleware\RouteMiddleware::class);
+$app->pipe(\Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware::class);
+$app->pipe(\Zend\Expressive\Router\Middleware\ImplicitOptionsMiddleware::class);
+$app->pipe(\Zend\Expressive\Router\Middleware\DispatchMiddleware::class);
+EOT;
+    }
+}

--- a/test/MigrateExpressive22/UpdateConfigTest.php
+++ b/test/MigrateExpressive22/UpdateConfigTest.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Tooling\MigrateExpressive22;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\Console\Output\OutputInterface;
+use Zend\Expressive\Tooling\MigrateExpressive22\UpdateConfig;
+
+class UpdateConfigTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->root = vfsStream::setup('expressive22');
+        $this->url = vfsStream::url('expressive22');
+        mkdir($this->url . '/config');
+        touch($this->url . '/config/config.php');
+    }
+
+    public function testInjectsProvidersInStandardSkeletonSetup()
+    {
+        $originalConfig = <<< 'EOT'
+<?php
+
+use Zend\ConfigAggregator\ArrayProvider;
+use Zend\ConfigAggregator\ConfigAggregator;
+use Zend\ConfigAggregator\PhpFileProvider;
+
+// To enable or disable caching, set the `ConfigAggregator::ENABLE_CACHE` boolean in
+// `config/autoload/local.php`.
+$cacheConfig = [
+    'config_cache_path' => 'data/config-cache.php',
+];
+
+$aggregator = new ConfigAggregator([
+    // Include cache configuration
+    new ArrayProvider($cacheConfig),
+
+    // Default App module config
+    App\ConfigProvider::class,
+
+    // Load application config in a pre-defined order in such a way that local settings
+    // overwrite global settings. (Loaded as first to last):
+    //   - `global.php`
+    //   - `*.global.php`
+    //   - `local.php`
+    //   - `*.local.php`
+    new PhpFileProvider(realpath(__DIR__) . '/autoload/{{,*.}global,{,*.}local}.php'),
+
+    // Load development config if it exists
+    new PhpFileProvider(realpath(__DIR__) . '/development.config.php'),
+], $cacheConfig['config_cache_path']);
+
+return $aggregator->getMergedConfig();
+EOT;
+
+        $expectedConfig = <<< 'EOT'
+<?php
+
+use Zend\ConfigAggregator\ArrayProvider;
+use Zend\ConfigAggregator\ConfigAggregator;
+use Zend\ConfigAggregator\PhpFileProvider;
+
+// To enable or disable caching, set the `ConfigAggregator::ENABLE_CACHE` boolean in
+// `config/autoload/local.php`.
+$cacheConfig = [
+    'config_cache_path' => 'data/config-cache.php',
+];
+
+$aggregator = new ConfigAggregator([
+    \Zend\Expressive\ConfigProvider::class,
+    \Zend\Expressive\Router\ConfigProvider::class,
+    // Include cache configuration
+    new ArrayProvider($cacheConfig),
+
+    // Default App module config
+    App\ConfigProvider::class,
+
+    // Load application config in a pre-defined order in such a way that local settings
+    // overwrite global settings. (Loaded as first to last):
+    //   - `global.php`
+    //   - `*.global.php`
+    //   - `local.php`
+    //   - `*.local.php`
+    new PhpFileProvider(realpath(__DIR__) . '/autoload/{{,*.}global,{,*.}local}.php'),
+
+    // Load development config if it exists
+    new PhpFileProvider(realpath(__DIR__) . '/development.config.php'),
+], $cacheConfig['config_cache_path']);
+
+return $aggregator->getMergedConfig();
+EOT;
+
+        $output = $this->prophesize(OutputInterface::class);
+        $output
+            ->writeln(Argument::containingString('Adding Zend\Expressive\Router\ConfigProvider to config'))
+            ->shouldBeCalled();
+        $output
+            ->writeln(Argument::containingString('Adding Zend\Expressive\ConfigProvider to config'))
+            ->shouldBeCalled();
+
+        $updateConfig = new UpdateConfig();
+
+        $this->assertNull($updateConfig($output->reveal(), $this->url));
+    }
+
+    public function testInjectsProvidersWhenConfigReferencesFullyQualifiedAggregatorClassName()
+    {
+        $originalConfig = <<< 'EOT'
+$aggregator = new \Zend\ConfigAggregator\ConfigAggregator([
+    // Include cache configuration
+    new \Zend\ConfigAggregator\ArrayProvider($cacheConfig),
+
+    // Default App module config
+    \App\ConfigProvider::class,
+
+    // Load application config in a pre-defined order in such a way that local settings
+    // overwrite global settings. (Loaded as first to last):
+    //   - `global.php`
+    //   - `*.global.php`
+    //   - `local.php`
+    //   - `*.local.php`
+    new \Zend\ConfigAggregator\PhpFileProvider(realpath(__DIR__) . '/autoload/{{,*.}global,{,*.}local}.php'),
+
+    // Load development config if it exists
+    new \Zend\ConfigAggregator\PhpFileProvider(realpath(__DIR__) . '/development.config.php'),
+], $cacheConfig['config_cache_path']);
+EOT;
+
+        $expectedConfig = <<< 'EOT'
+$aggregator = new \Zend\ConfigAggregator\ConfigAggregator([
+    \Zend\Expressive\ConfigProvider::class,
+    \Zend\Expressive\Router\ConfigProvider::class,
+    // Include cache configuration
+    new \Zend\ConfigAggregator\ArrayProvider($cacheConfig),
+
+    // Default App module config
+    \App\ConfigProvider::class,
+
+    // Load application config in a pre-defined order in such a way that local settings
+    // overwrite global settings. (Loaded as first to last):
+    //   - `global.php`
+    //   - `*.global.php`
+    //   - `local.php`
+    //   - `*.local.php`
+    new \Zend\ConfigAggregator\PhpFileProvider(realpath(__DIR__) . '/autoload/{{,*.}global,{,*.}local}.php'),
+
+    // Load development config if it exists
+    new \Zend\ConfigAggregator\PhpFileProvider(realpath(__DIR__) . '/development.config.php'),
+], $cacheConfig['config_cache_path']);
+EOT;
+
+        $output = $this->prophesize(OutputInterface::class);
+        $output
+            ->writeln(Argument::containingString('Adding Zend\Expressive\Router\ConfigProvider to config'))
+            ->shouldBeCalled();
+        $output
+            ->writeln(Argument::containingString('Adding Zend\Expressive\ConfigProvider to config'))
+            ->shouldBeCalled();
+
+        $updateConfig = new UpdateConfig();
+
+        $this->assertNull($updateConfig($output->reveal(), $this->url));
+    }
+}

--- a/test/MigrateExpressive22/UpdatePipelineTest.php
+++ b/test/MigrateExpressive22/UpdatePipelineTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Tooling\MigrateExpressive22;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\Console\Output\OutputInterface;
+use Zend\Expressive\Tooling\MigrateExpressive22\UpdatePipeline;
+
+class UpdatePipelineTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->root = vfsStream::setup('expressive22');
+        $this->url = vfsStream::url('expressive22');
+        mkdir($this->url . '/config');
+        touch($this->url . '/config/pipeline.php');
+    }
+
+    public function testUpdatesPipelineReferencingFullyQualifiedNames()
+    {
+        $originalContents = <<< 'EOT'
+$app->pipeRoutingMiddleware();
+$app->pipe(\Zend\Expressive\Middleware\ImplicitHeadMiddleware::class);
+$app->pipe(\Zend\Expressive\Middleware\ImplicitOptionsMiddleware::class);
+$app->pipeDispatchMiddleware();
+EOT;
+        file_put_contents($this->url . '/config/pipeline.php', $originalContents);
+
+        $expectedContents = <<< 'EOT'
+$app->pipe(\Zend\Expressive\Router\Middleware\RouteMiddleware::class);
+$app->pipe(\Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware::class);
+$app->pipe(\Zend\Expressive\Router\Middleware\ImplicitOptionsMiddleware::class);
+$app->pipe(\Zend\Expressive\Router\Middleware\DispatchMiddleware::class);
+EOT;
+
+        $output = $this->prophesize(OutputInterface::class);
+        $output->writeln(Argument::containingString('pipeRoutingMiddleware()'))->shouldBeCalled();
+        $output->writeln(Argument::containingString('ImplicitHeadMiddleware'))->shouldBeCalled();
+        $output->writeln(Argument::containingString('ImplicitOptionsMiddleware'))->shouldBeCalled();
+        $output->writeln(Argument::containingString('pipeDispatchMiddleware()'))->shouldBeCalled();
+
+        $command = new UpdatePipeline();
+        $this->assertNull($command($output->reveal(), $this->url));
+
+        $test = file_get_contents($this->url . '/config/pipeline.php');
+        $this->assertEquals($expectedContents, $test);
+    }
+
+    public function testUpdatesPipelineReferencingRelativeNames()
+    {
+        $originalContents = <<< 'EOT'
+$app->pipe(Zend\Expressive\Middleware\ImplicitHeadMiddleware::class);
+$app->pipe(Zend\Expressive\Middleware\ImplicitOptionsMiddleware::class);
+EOT;
+        file_put_contents($this->url . '/config/pipeline.php', $originalContents);
+
+        $expectedContents = <<< 'EOT'
+$app->pipe(\Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware::class);
+$app->pipe(\Zend\Expressive\Router\Middleware\ImplicitOptionsMiddleware::class);
+EOT;
+
+        $output = $this->prophesize(OutputInterface::class);
+        $output->writeln(Argument::containingString('ImplicitHeadMiddleware'))->shouldBeCalled();
+        $output->writeln(Argument::containingString('ImplicitOptionsMiddleware'))->shouldBeCalled();
+
+        $command = new UpdatePipeline();
+        $this->assertNull($command($output->reveal(), $this->url));
+
+        $test = file_get_contents($this->url . '/config/pipeline.php');
+        $this->assertEquals($expectedContents, $test);
+    }
+
+    public function testUpdatesPipelineReferencingClassNamesOnly()
+    {
+        $originalContents = <<< 'EOT'
+$app->pipe(ImplicitHeadMiddleware::class);
+$app->pipe(ImplicitOptionsMiddleware::class);
+EOT;
+        file_put_contents($this->url . '/config/pipeline.php', $originalContents);
+
+        $expectedContents = <<< 'EOT'
+$app->pipe(\Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware::class);
+$app->pipe(\Zend\Expressive\Router\Middleware\ImplicitOptionsMiddleware::class);
+EOT;
+
+        $output = $this->prophesize(OutputInterface::class);
+        $output->writeln(Argument::containingString('ImplicitHeadMiddleware'))->shouldBeCalled();
+        $output->writeln(Argument::containingString('ImplicitOptionsMiddleware'))->shouldBeCalled();
+
+        $command = new UpdatePipeline();
+        $this->assertNull($command($output->reveal(), $this->url));
+
+        $test = file_get_contents($this->url . '/config/pipeline.php');
+        $this->assertEquals($expectedContents, $test);
+    }
+
+    public function testUpdatesPipelineReferencingOnlyRoutingAndDispatchMiddleware()
+    {
+        $originalContents = <<< 'EOT'
+$app->pipeRoutingMiddleware();
+$app->pipeDispatchMiddleware();
+EOT;
+        file_put_contents($this->url . '/config/pipeline.php', $originalContents);
+
+        $expectedContents = <<< 'EOT'
+$app->pipe(\Zend\Expressive\Router\Middleware\RouteMiddleware::class);
+$app->pipe(\Zend\Expressive\Router\Middleware\DispatchMiddleware::class);
+EOT;
+
+        $output = $this->prophesize(OutputInterface::class);
+        $output->writeln(Argument::containingString('pipeRoutingMiddleware()'))->shouldBeCalled();
+        $output->writeln(Argument::containingString('pipeDispatchMiddleware()'))->shouldBeCalled();
+
+        $command = new UpdatePipeline();
+        $this->assertNull($command($output->reveal(), $this->url));
+
+        $test = file_get_contents($this->url . '/config/pipeline.php');
+        $this->assertEquals($expectedContents, $test);
+    }
+}


### PR DESCRIPTION
This command does the following:

- Adds Zend\Expressive\Router\ConfigProvider to config/config.php
- Adds Zend\Expressive\ConfigProvider to config/config.php
- Replaces `pipeRoutingMiddleware()` calls with `pipe(\Zend\Expressive\Router\Middleware\RouteMiddleware::class)`
- Replaces `pipeDispatchMiddleware()` calls with `pipe(\Zend\Expressive\Router\Middleware\DispatchMiddleware::class)`
- Replaces `pipe()` calls that pipe `Implicit*Middleware` to reference zend-expressive-router variants