### PR TITLE
Revert #69

### DIFF
--- a/src/Module/Create.php
+++ b/src/Module/Create.php
@@ -72,12 +72,7 @@ EOT;
      */
     public function process(string $moduleName, string $modulesPath, string $projectDir) : string
     {
-        $modulePath = sprintf(
-            '%s/%s/%s',
-            $projectDir,
-            $modulesPath,
-            str_replace('\\', DIRECTORY_SEPARATOR, $moduleName)
-        );
+        $modulePath = sprintf('%s/%s/%s', $projectDir, $modulesPath, $moduleName);
 
         $this->createDirectoryStructure($modulePath, $moduleName);
         $this->createConfigProvider($modulePath, $moduleName);
@@ -99,7 +94,7 @@ EOT;
             ));
         }
 
-        if (! mkdir($modulePath, 0777, true)) {
+        if (! mkdir($modulePath)) {
             throw new RuntimeException(sprintf(
                 'Module directory "%s" cannot be created',
                 $modulePath

--- a/test/Module/CreateTest.php
+++ b/test/Module/CreateTest.php
@@ -132,20 +132,4 @@ class CreateTest extends TestCase
         $expectedContent = sprintf($command::TEMPLATE_CONFIG_PROVIDER, 'MyApp', 'myapp');
         $this->assertSame($expectedContent, $configProviderContent);
     }
-
-    public function testCreateModuleWithNamespace()
-    {
-        $configProvider = vfsStream::url('project/my-modules/MyNamespace/MyModule/src/ConfigProvider.php');
-        $this->assertEquals(
-            sprintf('Created module MyNamespace\\MyModule in %s/MyNamespace/MyModule', $this->modulesDir->url()),
-            $this->command->process('MyNamespace\\MyModule', $this->modulesPath, $this->projectDir)
-        );
-        $this->assertFileExists($configProvider);
-        $configProviderContent = file_get_contents($configProvider);
-        $this->assertSame(1, preg_match('/\bnamespace MyNamespace\\\\MyModule\b/', $configProviderContent));
-        $this->assertSame(1, preg_match('/\bclass ConfigProvider\b/', $configProviderContent));
-        $command = $this->command;
-        $expectedContent = sprintf($command::TEMPLATE_CONFIG_PROVIDER, 'MyNamespace\\MyModule', 'mynamespace-mymodule');
-        $this->assertSame($expectedContent, $configProviderContent);
-    }
 }


### PR DESCRIPTION
This reverts commit 34eabc1f8c3acf1a51b971a88faf4f2857ac3227. PR #69.

```console
$ composer expressive module:create "MyName\\MyApp"
> expressive --ansi 'module:create' 'MyName\MyApp'
Using project autoloader based on current working directory
Created module MyName\MyApp in /var/www/3.0.0rc1/src/MyName/MyApp

In AbstractCommand.php line 138:
                                                                          
  Unable to determine autoloading type; no src directory found in module  
                                                                          

module:create [-c|--composer COMPOSER] [-p|--modules-path MODULES-PATH] [--] <module>

Script expressive --ansi handling the expressive event returned with error code 1
```

We need update `zf-composer-autoloading` to have it fully functional.