### PR TITLE
[WIP] fix 'alias already exists errors'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/console": "^2.8 || ^3.0 || ^4.0",
         "zendframework/zend-code": "^3.1 || ^2.6.3",
         "zendframework/zend-component-installer": "^1.0 || ^0.7.1",
-        "zendframework/zend-expressive": "^2.0",
+        "zendframework/zend-expressive": "^2.2",
         "zendframework/zend-stdlib": "^3.1",
         "zendframework/zend-stratigility": "^2.0",
         "zfcampus/zf-composer-autoloading": "^2.0"

--- a/src/GenerateProgrammaticPipelineFromConfig/Generator.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Generator.php
@@ -30,8 +30,6 @@ use Zend\Expressive\Container\NotFoundDelegateFactory;
 use Zend\Expressive\Container\NotFoundHandlerFactory;
 use Zend\Expressive\Delegate\NotFoundDelegate;
 use Zend\Expressive\Middleware\ErrorResponseGenerator;
-use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
-use Zend\Expressive\Middleware\ImplicitOptionsMiddleware;
 use Zend\Expressive\Middleware\NotFoundHandler;
 use Zend\Expressive\Router;
 use Zend\Stratigility\Middleware\ErrorHandler;
@@ -44,8 +42,6 @@ return [
             'Zend\Expressive\Delegate\DefaultDelegate' => NotFoundDelegate::class,
         ],
         'invokables' => [
-            ImplicitHeadMiddleware::class => ImplicitHeadMiddleware::class,
-            ImplicitOptionsMiddleware::class => ImplicitOptionsMiddleware::class,
             OriginalMessages::class => OriginalMessages::class,
         ],
         'factories' => [

--- a/src/GenerateProgrammaticPipelineFromConfig/Generator.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Generator.php
@@ -26,10 +26,14 @@ class Generator implements Constants
 
 use Zend\Expressive\Container\ErrorHandlerFactory;
 use Zend\Expressive\Container\ErrorResponseGeneratorFactory;
+use Zend\Expressive\Container\NotFoundDelegateFactory;
 use Zend\Expressive\Container\NotFoundHandlerFactory;
 use Zend\Expressive\Delegate\NotFoundDelegate;
 use Zend\Expressive\Middleware\ErrorResponseGenerator;
+use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
+use Zend\Expressive\Middleware\ImplicitOptionsMiddleware;
 use Zend\Expressive\Middleware\NotFoundHandler;
+use Zend\Expressive\Router;
 use Zend\Stratigility\Middleware\ErrorHandler;
 use Zend\Stratigility\Middleware\OriginalMessages;
 
@@ -40,6 +44,8 @@ return [
             'Zend\Expressive\Delegate\DefaultDelegate' => NotFoundDelegate::class,
         ],
         'invokables' => [
+            ImplicitHeadMiddleware::class => ImplicitHeadMiddleware::class,
+            ImplicitOptionsMiddleware::class => ImplicitOptionsMiddleware::class,
             OriginalMessages::class => OriginalMessages::class,
         ],
         'factories' => [
@@ -49,7 +55,11 @@ return [
             // in order to use Whoops for development error handling.
             ErrorResponseGenerator::class => ErrorResponseGeneratorFactory::class,
             // Override the following to use an alternate "not found" delegate.
+            NotFoundDelegate::class => NotFoundDelegateFactory::class,
             NotFoundHandler::class => NotFoundHandlerFactory::class,
+            // These are duplicates, in case the zend-expressive-router package ConfigProvider is not wired:
+            Router\Middleware\ImplicitHeadMiddleware::class => Router\Middleware\ImplicitHeadMiddlewareFactory::class,
+            Router\Middleware\ImplicitOptionsMiddleware::class => Router\Middleware\ImplicitOptionsMiddlewareFactory::class,
         ],
     ],
     'zend-expressive' => [

--- a/src/GenerateProgrammaticPipelineFromConfig/Generator.php
+++ b/src/GenerateProgrammaticPipelineFromConfig/Generator.php
@@ -26,12 +26,9 @@ class Generator implements Constants
 
 use Zend\Expressive\Container\ErrorHandlerFactory;
 use Zend\Expressive\Container\ErrorResponseGeneratorFactory;
-use Zend\Expressive\Container\NotFoundDelegateFactory;
 use Zend\Expressive\Container\NotFoundHandlerFactory;
 use Zend\Expressive\Delegate\NotFoundDelegate;
 use Zend\Expressive\Middleware\ErrorResponseGenerator;
-use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
-use Zend\Expressive\Middleware\ImplicitOptionsMiddleware;
 use Zend\Expressive\Middleware\NotFoundHandler;
 use Zend\Stratigility\Middleware\ErrorHandler;
 use Zend\Stratigility\Middleware\OriginalMessages;
@@ -43,8 +40,6 @@ return [
             'Zend\Expressive\Delegate\DefaultDelegate' => NotFoundDelegate::class,
         ],
         'invokables' => [
-            ImplicitHeadMiddleware::class => ImplicitHeadMiddleware::class,
-            ImplicitOptionsMiddleware::class => ImplicitOptionsMiddleware::class,
             OriginalMessages::class => OriginalMessages::class,
         ],
         'factories' => [
@@ -54,7 +49,6 @@ return [
             // in order to use Whoops for development error handling.
             ErrorResponseGenerator::class => ErrorResponseGeneratorFactory::class,
             // Override the following to use an alternate "not found" delegate.
-            NotFoundDelegate::class => NotFoundDelegateFactory::class,
             NotFoundHandler::class => NotFoundHandlerFactory::class,
         ],
     ],

--- a/test/GenerateProgrammaticPipelineFromConfig/TestAsset/expected/config/autoload/programmatic-pipeline.global.php
+++ b/test/GenerateProgrammaticPipelineFromConfig/TestAsset/expected/config/autoload/programmatic-pipeline.global.php
@@ -9,8 +9,6 @@ use Zend\Expressive\Container\NotFoundDelegateFactory;
 use Zend\Expressive\Container\NotFoundHandlerFactory;
 use Zend\Expressive\Delegate\NotFoundDelegate;
 use Zend\Expressive\Middleware\ErrorResponseGenerator;
-use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
-use Zend\Expressive\Middleware\ImplicitOptionsMiddleware;
 use Zend\Expressive\Middleware\NotFoundHandler;
 use Zend\Expressive\Router;
 use Zend\Stratigility\Middleware\ErrorHandler;
@@ -23,8 +21,6 @@ return [
             'Zend\Expressive\Delegate\DefaultDelegate' => NotFoundDelegate::class,
         ],
         'invokables' => [
-            ImplicitHeadMiddleware::class => ImplicitHeadMiddleware::class,
-            ImplicitOptionsMiddleware::class => ImplicitOptionsMiddleware::class,
             OriginalMessages::class => OriginalMessages::class,
         ],
         'factories' => [

--- a/test/GenerateProgrammaticPipelineFromConfig/TestAsset/expected/config/autoload/programmatic-pipeline.global.php
+++ b/test/GenerateProgrammaticPipelineFromConfig/TestAsset/expected/config/autoload/programmatic-pipeline.global.php
@@ -12,6 +12,7 @@ use Zend\Expressive\Middleware\ErrorResponseGenerator;
 use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
 use Zend\Expressive\Middleware\ImplicitOptionsMiddleware;
 use Zend\Expressive\Middleware\NotFoundHandler;
+use Zend\Expressive\Router;
 use Zend\Stratigility\Middleware\ErrorHandler;
 use Zend\Stratigility\Middleware\OriginalMessages;
 
@@ -35,6 +36,9 @@ return [
             // Override the following to use an alternate "not found" delegate.
             NotFoundDelegate::class => NotFoundDelegateFactory::class,
             NotFoundHandler::class => NotFoundHandlerFactory::class,
+            // These are duplicates, in case the zend-expressive-router package ConfigProvider is not wired:
+            Router\Middleware\ImplicitHeadMiddleware::class => Router\Middleware\ImplicitHeadMiddlewareFactory::class,
+            Router\Middleware\ImplicitOptionsMiddleware::class => Router\Middleware\ImplicitOptionsMiddlewareFactory::class,
         ],
     ],
     'zend-expressive' => [


### PR DESCRIPTION
does not need those options becouse already defined here https://github.com/zendframework/zend-expressive/blob/2.2.1/src/ConfigProvider.php#L39-L42 and throws those exceptions
```
An alias by the name "zendexpressivedelegatenotfounddelegate" or "Zend\Expressive\Delegate\NotFoundDelegate" already exists
An alias by the name "zendexpressivemiddlewareimplicitheadmiddleware" or "Zend\Expressive\Middleware\ImplicitHeadMiddleware" already exists 
An alias by the name "zendexpressivemiddlewareimplicitoptionsmiddleware" or "Zend\Expressive\Middleware\ImplicitOptionsMiddleware" already exists
```

this should be rebased and merged only to 0.4 version