### PR TITLE
Added strict_type declaration to the generated config file

### DIFF
--- a/src/Factory/ConfigInjector.php
+++ b/src/Factory/ConfigInjector.php
@@ -32,6 +32,8 @@ class ConfigInjector
  * removing factory definitions; other dependency types may be overwritten
  * when regenerating this file via zend-expressive-tooling commands.
  */
+ 
+declare(strict_types=1);
 
 return [
     'dependencies' => [


### PR DESCRIPTION
Updates the configuration file generated to map services to factories to include a `strict_types` declaration.