### PR TITLE
Remove unnecessary  docblocks

### DIFF
--- a/src/CreateHandler/ClassSkeletons.php
+++ b/src/CreateHandler/ClassSkeletons.php
@@ -27,9 +27,6 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class %class% implements RequestHandlerInterface
 {
-    /**
-     * {@inheritDoc}
-     */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         // Create and return a response
@@ -66,9 +63,6 @@ class %class% implements RequestHandlerInterface
         $this->renderer = $renderer;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         // Do some work...

--- a/src/CreateMiddleware/CreateMiddleware.php
+++ b/src/CreateMiddleware/CreateMiddleware.php
@@ -33,9 +33,6 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class %class% implements MiddlewareInterface
 {
-    /**
-     * {@inheritDoc}
-     */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         // $response = $handler->handle($request);


### PR DESCRIPTION
This PR removes unnecessary `{@inheritDoc}` docblocks in generated code.