### PR TITLE
Avoid cryptic error message when attempting to create a non-namespaced handler/action

### DIFF
--- a/src/CreateHandler/TemplateResolutionTrait.php
+++ b/src/CreateHandler/TemplateResolutionTrait.php
@@ -41,7 +41,11 @@ trait TemplateResolutionTrait
      */
     private function getNamespace(string $class) : string
     {
-        return substr($class, 0, strpos($class, '\\'));
+        $topLevelOffset = strpos($class, '\\');
+
+        return ($topLevelOffset !== false)
+            ? substr($class, 0, $topLevelOffset)
+            : $class;
     }
 
     /**

--- a/src/CreateHandler/TemplateResolutionTrait.php
+++ b/src/CreateHandler/TemplateResolutionTrait.php
@@ -62,7 +62,9 @@ trait TemplateResolutionTrait
      */
     private function getClassName(string $class) : string
     {
-        return substr($class, strrpos($class, '\\') + 1);
+        return (strpos($class, '\\') !== false)
+            ? substr($class, strrpos($class, '\\') + 1)
+            : $class;
     }
 
     /**


### PR DESCRIPTION
**Provide a narrative description of what you are trying to accomplish:**

Provide a less cryptic error message for users trying to create a handler and/or action when not typing in a namespaced class.

- [x] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

When you install Zend Expressive and go to create your first action/handler with the CLI,

Entering something like:

`composer expressive action:create HomePageAction`

results in the following cryptic error message that is not so friendly:

`Fatal error: Uncaught TypeError: substr() expects parameter 3 to be integer, boolean given in [path/to/zendframework/zend-expressive-tooling/src/CreateHandler/TemplateResolutionTrait.php]:44`

The error occurs in line 44 because the handler/action specified is not namespaced, therefore it does not have any backslash characters in the string, making strpos return boolean false in the 3rd argument of substr.

Using a conditional return it will fallback to the CreateHandlerException and say:

`"Unable to match [HomePageAction] to an autoloadable PSR-4 namespace"`

This is the behavior that occurs if you do the same thing with the middleware:create command.

Just a friendlier message for beginners.
