### PR TITLE
Feature/configurable command options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#86](https://github.com/zendframework/zend-expressive-tooling/pull/86) Configurable default command options values.
+  Making **modules-path** configurable so it is not required to provide it on each cli execution. Until now it was
+  necessary to provide the parameter: `./vendor/bin/expressive module:create MyModule --modules-path custom-directory`.
+  Now you can configure the modules-path and omit it on cli execution `./vendor/bin/expressive module:create MyModule`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -35,3 +35,27 @@ $ composer require --dev zendframework/zend-expressive-tooling
     application.
   - **module:deregister**: Deregister a middleware module from the application.
   - **module:register**: Register a middleware module with the application.
+
+## Configurable command option values
+
+If the modules-path of your project is not under `src` you can either provide the
+path via the `--modules-path` parameter or configure it in your application
+configuration. By adding the changed path to you configuration you can omit the
+`--modules-path` on cli execution for the `module:create` command.
+
+```php
+// In config/autoload/application.global.php:
+
+<?php
+
+declare(strict_types = 1);
+
+use Zend\Expressive\Tooling\Module\CommandCommonOptions;
+
+return [
+    /* ... */
+    CommandCommonOptions::class => [
+        'modules_path' => 'custom-directory',
+    ],
+];
+```

--- a/src/ConfigAndContainerTrait.php
+++ b/src/ConfigAndContainerTrait.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018-2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Tooling;
+
+use Psr\Container\ContainerInterface;
+
+trait ConfigAndContainerTrait
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    private function getContainer(string $projectPath) : ContainerInterface
+    {
+        if ($this->container) {
+            return $this->container;
+        }
+
+        $containerPath = sprintf('%s/config/container.php', $projectPath);
+        $this->container = require $containerPath;
+        return $this->container;
+    }
+
+    /**
+     * Retrieve project configuration.
+     */
+    private function getConfig(string $projectPath) : array
+    {
+        return $this->getContainer($projectPath)->get('config');
+    }
+}

--- a/src/Module/CommandCommonOptions.php
+++ b/src/Module/CommandCommonOptions.php
@@ -48,12 +48,18 @@ final class CommandCommonOptions
     }
 
     /**
-     * Retrieve the modules path from input
+     * Retrieve the modules path from  1: $input, 2: project config or 3: default 'src'
+     *
+     * @param InputInterface $input
+     * @param array $config
+     * @return string
      */
-    public static function getModulesPath(InputInterface $input) : string
+    public static function getModulesPath(InputInterface $input, array $config = []) : string
     {
-        $modulesPath = $input->getOption('modules-path') ?: 'src';
-        $modulesPath = preg_replace('/^\.\//', '', str_replace('\\', '/', $modulesPath));
+        $configuredModulesPath = $config[self::class]['modules_path'] ?? null;
+        $modulesPath           = $input->getOption('modules-path') ?? $configuredModulesPath ?: 'src';
+        $modulesPath           = preg_replace('/^\.\//', '', str_replace('\\', '/', $modulesPath));
+
         return $modulesPath;
     }
 }

--- a/src/Module/CreateCommand.php
+++ b/src/Module/CreateCommand.php
@@ -13,9 +13,12 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Zend\Expressive\Tooling\TemplateResolutionTrait;
 
 class CreateCommand extends Command
 {
+    use TemplateResolutionTrait;
+
     public const HELP = <<< 'EOT'
 Create a new middleware module for the application.
 
@@ -51,7 +54,8 @@ EOT;
     {
         $module = $input->getArgument('module');
         $composer = $input->getOption('composer') ?: 'composer';
-        $modulesPath = CommandCommonOptions::getModulesPath($input);
+        $config = $this->getConfig(realpath(getcwd()));
+        $modulesPath = CommandCommonOptions::getModulesPath($input, $config);
 
         $creation = new Create();
         $message = $creation->process($module, $modulesPath, getcwd());

--- a/src/Module/CreateCommand.php
+++ b/src/Module/CreateCommand.php
@@ -13,11 +13,11 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Zend\Expressive\Tooling\TemplateResolutionTrait;
+use Zend\Expressive\Tooling\ConfigAndContainerTrait;
 
 class CreateCommand extends Command
 {
-    use TemplateResolutionTrait;
+    use ConfigAndContainerTrait;
 
     public const HELP = <<< 'EOT'
 Create a new middleware module for the application.

--- a/src/TemplateResolutionTrait.php
+++ b/src/TemplateResolutionTrait.php
@@ -20,10 +20,7 @@ use function substr;
 
 trait TemplateResolutionTrait
 {
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
+    use ConfigAndContainerTrait;
 
     /**
      * Normalizes identifier to lowercase, dash-separated words.
@@ -81,25 +78,6 @@ trait TemplateResolutionTrait
                 $this->getClassName($class)
             )
         );
-    }
-
-    private function getContainer(string $projectPath) : ContainerInterface
-    {
-        if ($this->container) {
-            return $this->container;
-        }
-
-        $containerPath = sprintf('%s/config/container.php', $projectPath);
-        $this->container = require $containerPath;
-        return $this->container;
-    }
-
-    /**
-     * Retrieve project configuration.
-     */
-    private function getConfig(string $projectPath) : array
-    {
-        return $this->getContainer($projectPath)->get('config');
     }
 
     /**

--- a/test/Module/CommandCommonOptionsTest.php
+++ b/test/Module/CommandCommonOptionsTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Tooling\Module;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Console\Input\InputInterface;
+use Zend\Expressive\Tooling\Module\CommandCommonOptions;
+
+class CommandCommonOptionsTest extends TestCase
+{
+    /** @var InputInterface|ObjectProphecy */
+    private $input;
+
+    protected function setUp()
+    {
+        $this->input = $this->prophesize(InputInterface::class);
+    }
+
+    public function testGetModulesPathGetsOptionsFromInput() : void
+    {
+        $this->input->getOption('modules-path')->willReturn('path-from-input');
+        $config[CommandCommonOptions::class]['modules_path'] = 'path-from-config';
+
+        $this->assertEquals(
+            'path-from-input',
+            CommandCommonOptions::getModulesPath($this->input->reveal(), $config)
+        );
+    }
+
+    public function testGetModulesPathGetsOptionsFromConfig() : void
+    {
+        $this->input->getOption('modules-path')->willReturn(null);
+        $config[CommandCommonOptions::class]['modules_path'] = 'path-from-config';
+
+        $this->assertEquals(
+            'path-from-config',
+            CommandCommonOptions::getModulesPath($this->input->reveal(), $config)
+        );
+    }
+
+    public function testGetModulesPathGetsDefaultOption() : void
+    {
+        $this->input->getOption('modules-path')->willReturn(null);
+
+        $this->assertEquals(
+            'src',
+            CommandCommonOptions::getModulesPath($this->input->reveal())
+        );
+    }
+}

--- a/test/Module/TestAsset/config/config.php
+++ b/test/Module/TestAsset/config/config.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+return [];


### PR DESCRIPTION
…ath in module:create command

Making command option values configurable as suggested in #84.

- Are you fixing a bug? _No_

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve? _See #84_ 
  - [x] How will users use the new feature? _See #84_ 
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add tests for the new feature.
  - [x] Add documentation for the new feature.
  - [x] Add a `CHANGELOG.md` entry for the new feature.

- Is this related to quality assurance? _No_
  <!-- Detail why the changes are necessary -->

- Is this related to documentation? _No_

This is my first code-changing PR on a ZF repo. I appreciate any feedback. In particular I am not sure if 1) this is the right way to go and 2) which other command options might benefit from an configurable implementation.