### PR TITLE
Bugfix/config-array

### DIFF
--- a/src/ConfigAndContainerTrait.php
+++ b/src/ConfigAndContainerTrait.php
@@ -10,6 +10,15 @@ declare(strict_types=1);
 namespace Zend\Expressive\Tooling;
 
 use Psr\Container\ContainerInterface;
+use RuntimeException;
+use Traversable;
+
+use get_class;
+use gettype;
+use is_array;
+use is_object;
+use iterator_to_array;
+use sprintf;
 
 trait ConfigAndContainerTrait
 {
@@ -34,6 +43,20 @@ trait ConfigAndContainerTrait
      */
     private function getConfig(string $projectPath) : array
     {
-        return $this->getContainer($projectPath)->get('config');
+        $config = $this->getContainer($projectPath)->get('config');
+
+        if (is_array($config)) {
+            return $config;
+        }
+
+        if (! $config instanceof Traversable) {
+            $error = sprintf(
+                '"config" service must be an array or instance of ArrayObject or Traversable, got %s',
+                is_object($config) ? get_class($config) : gettype($config)
+            );
+            throw new RuntimeException($error);
+        }
+
+        return iterator_to_array($config);
     }
 }


### PR DESCRIPTION
### Detail how the bug is invoked currently.
- `$ composer create-project zendframework/zend-expressive-skeleton expressive`
- Select `Aura\Di` as the container
- `$ composer expressive action:create "App\FooBar"`
```
PHP Fatal error:  Uncaught TypeError: Return value of
Zend\Expressive\Tooling\CreateHandler\CreateTemplate::getConfig() must be of the
type array, object returned [...] /ConfigAndContainerTrait.php:37
```

### Detail the original, incorrect behavior.
[Aura\Di uses an ArrayObject][ArrayObject] for the `config` key. Returning it
from this method with a return type of `array` produces an error.

### Detail the new, expected behavior.
This just casts the value to an array `return (array) [...]`
Alternatively we could:
- Change the return type
- Check if it's an `ArrayObject` and call `getArrayCopy()`
- Something else


[ArrayObject]: https://github.com/zendframework/zend-auradi-config/blob/1c8295d3f698a630909b6eeb57b7009af2479fae/src/Config.php#L65
