### PR TITLE
Update composer.json: Package `ocramius/package-versions` requires PHP 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.1",
+        "php": "^7.3",
         "ext-json": "*",
         "ocramius/package-versions": "^1.3",
         "symfony/console": "^2.8 || ^3.0 || ^4.0",


### PR DESCRIPTION
Package `ocramius/package-versions` requires PHP 7.3 (see [`composer.json`](https://github.com/Ocramius/PackageVersions/blob/master/composer.json))

Provide a narrative description of what you are trying to accomplish:

The last version of `ocramius/package-versions`` requires PHP 7.3.

Here is the "error" I get on PHP 7.2

```
  Problem 1
    - Installation request for ocramius/package-versions 1.5.1 -> satisfiable by ocramius/package-versions[1.5.1].
    - ocramius/package-versions 1.5.1 requires php ^7.3.0 -> your PHP version (7.2.17) does not satisfy that requirement.
  Problem 2
    - ocramius/package-versions 1.5.1 requires php ^7.3.0 -> your PHP version (7.2.17) does not satisfy that requirement.
    - zendframework/zend-expressive-tooling 1.2.0 requires ocramius/package-versions ^1.3 -> satisfiable by ocramius/package                                            -versions[1.5.1].
    - Installation request for zendframework/zend-expressive-tooling 1.2.0 -> satisfiable by zendframework/zend-expressive-t                                            ooling[1.2.0].
```

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.
