### PR TITLE
Bugfix: config can be an array or an ArrayObject (follow up #89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#93](https://github.com/zendframework/zend-expressive-tooling/pull/93) fixes
+  issue with DI containers where configuration is an ArrayObject not an array.
+  `handler:create` command works now properly with `Aura.Di` and `Symfony DI` containers.
 
 ## 1.2.0 - 2019-03-05
 

--- a/src/ConfigAndContainerTrait.php
+++ b/src/ConfigAndContainerTrait.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 
 namespace Zend\Expressive\Tooling;
 
+use ArrayObject;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
-use Traversable;
 
 use function get_class;
 use function gettype;
@@ -49,9 +49,9 @@ trait ConfigAndContainerTrait
             return $config;
         }
 
-        if (! $config instanceof Traversable) {
+        if (! $config instanceof ArrayObject) {
             $error = sprintf(
-                '"config" service must be an array or instance of ArrayObject or Traversable, got %s',
+                '"config" service must be an array or instance of ArrayObject, got %s',
                 is_object($config) ? get_class($config) : gettype($config)
             );
             throw new RuntimeException($error);

--- a/src/ConfigAndContainerTrait.php
+++ b/src/ConfigAndContainerTrait.php
@@ -10,6 +10,15 @@ declare(strict_types=1);
 namespace Zend\Expressive\Tooling;
 
 use Psr\Container\ContainerInterface;
+use RuntimeException;
+use Traversable;
+
+use get_class;
+use gettype;
+use is_array;
+use is_object;
+use iterator_to_array;
+use sprintf;
 
 trait ConfigAndContainerTrait
 {
@@ -34,6 +43,20 @@ trait ConfigAndContainerTrait
      */
     private function getConfig(string $projectPath) : array
     {
-        return $this->getContainer($projectPath)->get('config');
+        $config = $this->getContainer($projectPath)->get('config');
+
+        if (is_array($config)) {
+            return $config;
+        }
+
+        if (! $config instanceof Traversable) {
+            $error = sprintf(
+                '"config" service must be an array or instance of ArrayObject or Traversable, got %s',
+                is_object($config) ? get_class($config) : gettype($config)
+            );
+            throw new RuntimeException($error);
+        }
+
+        return iterator_to_array($config);
     }
 }

--- a/src/ConfigAndContainerTrait.php
+++ b/src/ConfigAndContainerTrait.php
@@ -13,12 +13,12 @@ use Psr\Container\ContainerInterface;
 use RuntimeException;
 use Traversable;
 
-use get_class;
-use gettype;
-use is_array;
-use is_object;
-use iterator_to_array;
-use sprintf;
+use function get_class;
+use function gettype;
+use function is_array;
+use function is_object;
+use function iterator_to_array;
+use function sprintf;
 
 trait ConfigAndContainerTrait
 {

--- a/test/ConfigAndContainerTraitTest.php
+++ b/test/ConfigAndContainerTraitTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Tooling;
+
+use ArrayObject;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+use stdClass;
+use Zend\Expressive\Tooling\ConfigAndContainerTrait;
+
+class ConfigAndContainerTraitTest extends TestCase
+{
+    /** @var vfsStreamDirectory */
+    private $dir;
+
+    /** @var string */
+    private $projectRoot;
+
+    protected function setUp() : void
+    {
+        $this->dir = vfsStream::setup('project');
+        $this->projectRoot = vfsStream::url('project');
+
+        vfsStream::copyFromFileSystem(__DIR__ . '/TestAsset', $this->dir);
+    }
+
+    public function testGetContainer() : void
+    {
+        $class = new class ()
+        {
+            use ConfigAndContainerTrait;
+
+            public function container(string $projectPath)
+            {
+                return $this->getContainer($projectPath);
+            }
+        };
+
+        self::assertInstanceOf(ContainerInterface::class, $class->container($this->projectRoot));
+    }
+
+    public function testGetConfigAsArray() : void
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get('config')->willReturn(['foo' => 'bar']);
+
+        $class = new class ($container->reveal())
+        {
+            use ConfigAndContainerTrait;
+
+            public function __construct(ContainerInterface $container)
+            {
+                $this->container = $container;
+            }
+
+            public function config()
+            {
+                return $this->getConfig('');
+            }
+        };
+
+        self::assertSame(['foo' => 'bar'], $class->config());
+    }
+
+    public function testGetConfigAsArrayObject() : void
+    {
+        $config = new ArrayObject(['bar' => 'baz']);
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get('config')->willReturn($config);
+
+        $class = new class ($container->reveal())
+        {
+            use ConfigAndContainerTrait;
+
+            public function __construct(ContainerInterface $container)
+            {
+                $this->container = $container;
+            }
+
+            public function config()
+            {
+                return $this->getConfig('');
+            }
+        };
+
+        self::assertSame(['bar' => 'baz'], $class->config());
+    }
+
+    public function testConfigHasInvalidType() : void
+    {
+        $config = new stdClass();
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get('config')->willReturn($config);
+
+        $class = new class ($container->reveal())
+        {
+            use ConfigAndContainerTrait;
+
+            public function __construct(ContainerInterface $container)
+            {
+                $this->container = $container;
+            }
+
+            public function config()
+            {
+                return $this->getConfig('');
+            }
+        };
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('"config" service must be an array or instance of ArrayObject');
+        $class->config();
+    }
+}

--- a/test/TestAsset/config/container.php
+++ b/test/TestAsset/config/container.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-tooling for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-tooling/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+use Prophecy\Prophet;
+use Psr\Container\ContainerInterface;
+
+$prophet = new Prophet();
+$container = $prophet->prophesize(ContainerInterface::class);
+
+return $container->reveal();


### PR DESCRIPTION
Follow up #89.
Because author of PR #89 - @jakejohns didn't provide test and didn't set access for maintainers to push to his branch I'm creating this PR with work done in #89 + added test to cover changes.

Expressive configuration can be an array or ArrayObject (Symfony DI, AuraDI containers).

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.
